### PR TITLE
fix: KituraContracts typealias and completion on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,6 @@ grade.save { (id: Int?, grade: Grade?, error: RequestError?) in
 }
 ```
 
-**NB**: If you want to use `RequestError`, you'll need to import `KituraContracts` at the top of your swift file.
-
 ### Updating
 
 If you have the id for an existing record of your object, and you'd like to update the record with an object, you can use the `update()` function to do so:

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -19,6 +19,8 @@ import KituraContracts
 import Foundation
 import Dispatch
 
+public typealias RequestError = KituraContracts.RequestError
+
 public protocol Model: Codable {
   static var tableName: String {get}
   static var idColumnName: String {get}
@@ -36,7 +38,7 @@ public protocol Model: Codable {
   static func findAll<I: Identifier>(using db: Database?, _ onCompletion: @escaping ([(I, Self)]?, RequestError?) -> Void)
   static func findAll<I: Identifier>(using db: Database?, _ onCompletion: @escaping ([I: Self]?, RequestError?) -> Void)
 
-  func update<I: Identifier>(id: I, using db: Database?, onCompletion: @escaping (Identifier?, Self?, RequestError?) -> Void)
+  func update<I: Identifier>(id: I, using db: Database?, _ onCompletion: @escaping (Identifier?, Self?, RequestError?) -> Void)
 
   static func delete(id: Identifier, using db: Database?, _ onCompletion: @escaping (RequestError?) -> Void)
   static func deleteAll(using db: Database?, _ onCompletion: @escaping (RequestError?) -> Void)
@@ -624,7 +626,7 @@ public extension Model {
   /// - Parameter id: Identifier of the model to update
   /// - Parameter using: Optional Database to use
   /// - Returns: A tuple (id, model, error)
-  func update<I: Identifier>(id: I, using db: Database? = nil, onCompletion: @escaping (Identifier?, Self?, RequestError?) -> Void) {
+  func update<I: Identifier>(id: I, using db: Database? = nil, _ onCompletion: @escaping (Identifier?, Self?, RequestError?) -> Void) {
     guard let database = db ?? Database.default else {
       onCompletion(nil, nil, .ormDatabaseNotInitialized)
       return


### PR DESCRIPTION
- Create a public typealias for `RequestError` , so no need to import `KituraContracts`
- Remove note in `README.md`
- Added `_` to onCompletion argument for update, so no need to specify `onCompletion:`