### PR TITLE
fix: Expose RequestError as typealias

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,6 @@ grade.save { (id: Int?, grade: Grade?, error: RequestError?) in
 }
 ```
 
-**NB**: If you want to use `RequestError`, you'll need to import `KituraContracts` at the top of your swift file.
-
 ### Updating
 
 If you have the id for an existing record of your object, and you'd like to update the record with an object, you can use the `update()` function to do so:

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -19,6 +19,8 @@ import KituraContracts
 import Foundation
 import Dispatch
 
+public typealias RequestError = KituraContracts.RequestError
+
 public protocol Model: Codable {
   static var tableName: String {get}
   static var idColumnName: String {get}


### PR DESCRIPTION
- Create a public typealias for `RequestError` , so no need to import `KituraContracts`
- Remove note in `README.md`