### PR TITLE
Remove Identifier from the completion handler for find(id:)

### DIFF
--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -314,7 +314,7 @@ public extension Model {
 
   /// Find a model with an id
   /// - Parameter using: Optional Database to use
-  /// - Returns: A tuple (Identifier, Model, RequestError)
+  /// - Returns: A tuple (Model, RequestError)
   static func find<I: Identifier>(id: I, using db: Database? = nil, onCompletion: @escaping (Self?, RequestError?) -> Void) {
     guard let database = db ?? Database.default else {
       onCompletion(nil, .ormDatabaseNotInitialized)
@@ -625,7 +625,7 @@ public extension Model {
   /// Update a model
   /// - Parameter id: Identifier of the model to update
   /// - Parameter using: Optional Database to use
-  /// - Returns: A tuple (id, model, error)
+  /// - Returns: A tuple (model, error)
   func update<I: Identifier>(id: I, using db: Database? = nil, _ onCompletion: @escaping (Self?, RequestError?) -> Void) {
     guard let database = db ?? Database.default else {
       onCompletion(nil, .ormDatabaseNotInitialized)

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -38,7 +38,7 @@ public protocol Model: Codable {
   static func findAll<I: Identifier>(using db: Database?, _ onCompletion: @escaping ([(I, Self)]?, RequestError?) -> Void)
   static func findAll<I: Identifier>(using db: Database?, _ onCompletion: @escaping ([I: Self]?, RequestError?) -> Void)
 
-  func update<I: Identifier>(id: I, using db: Database?, _ onCompletion: @escaping (Identifier?, Self?, RequestError?) -> Void)
+  func update<I: Identifier>(id: I, using db: Database?, _ onCompletion: @escaping (Self?, RequestError?) -> Void)
 
   static func delete(id: Identifier, using db: Database?, _ onCompletion: @escaping (RequestError?) -> Void)
   static func deleteAll(using db: Database?, _ onCompletion: @escaping (RequestError?) -> Void)
@@ -626,13 +626,13 @@ public extension Model {
   /// - Parameter id: Identifier of the model to update
   /// - Parameter using: Optional Database to use
   /// - Returns: A tuple (id, model, error)
-  func update<I: Identifier>(id: I, using db: Database? = nil, _ onCompletion: @escaping (Identifier?, Self?, RequestError?) -> Void) {
+  func update<I: Identifier>(id: I, using db: Database? = nil, _ onCompletion: @escaping (Self?, RequestError?) -> Void) {
     guard let database = db ?? Database.default else {
-      onCompletion(nil, nil, .ormDatabaseNotInitialized)
+      onCompletion(nil, .ormDatabaseNotInitialized)
       return
     }
     guard let connection = database.getConnection() else {
-      onCompletion(nil, nil, .ormConnectionFailed)
+      onCompletion(nil, .ormConnectionFailed)
       return
     }
 
@@ -640,7 +640,7 @@ public extension Model {
     do {
       table = try Self.getTable()
     } catch {
-      onCompletion(nil, nil, Self.convertError(error))
+      onCompletion(nil, Self.convertError(error))
       return
     }
 
@@ -648,14 +648,14 @@ public extension Model {
     do {
       values = try DatabaseEncoder().encode(self)
     } catch {
-      onCompletion(nil, nil, Self.convertError(error))
+      onCompletion(nil, Self.convertError(error))
       return
     }
 
     let columns = table.columns.filter({$0.name != Self.idColumnName})
     let valueTuples = columns.filter({values[$0.name] != nil}).map({($0, values[$0.name]!)})
     guard let idColumn = table.columns.first(where: {$0.name == Self.idColumnName}) else {
-      onCompletion(nil, nil, RequestError(rawValue: 708, reason: "Could not find id column"))
+      onCompletion(nil, RequestError(rawValue: 708, reason: "Could not find id column"))
       return
     }
 
@@ -663,19 +663,19 @@ public extension Model {
 
     connection.connect {error in
       if let error = error {
-        onCompletion(nil, nil, Self.convertError(error))
+        onCompletion(nil, Self.convertError(error))
         return
       } else {
         connection.execute(query: query) { result in
           guard result.success else {
             guard let error = result.asError else {
-              onCompletion(nil, nil, Self.convertError(QueryError.databaseError("Query failed to execute but error was nil")))
+              onCompletion(nil, Self.convertError(QueryError.databaseError("Query failed to execute but error was nil")))
               return
             }
-            onCompletion(nil, nil, Self.convertError(error))
+            onCompletion(nil, Self.convertError(error))
             return
           }
-          onCompletion(id, self,nil)
+          onCompletion(self,nil)
         }
       }
     }

--- a/Tests/SwiftKueryORMTests/TestFind.swift
+++ b/Tests/SwiftKueryORMTests/TestFind.swift
@@ -22,7 +22,7 @@ class TestFind: XCTestCase {
         let connection: TestConnection = createConnection(.returnOneRow)
         Database.default = Database(single: connection)
         performTest(asyncTasks: { expectation in
-            Person.find(id: 1) { id, p, error in
+            Person.find(id: 1) { p, error in
                 XCTAssertNil(error, "Find Failed: \(String(describing: error))")
                 XCTAssertNotNil(connection.query, "Find Failed: Query is nil")
                 if let query = connection.query {


### PR DESCRIPTION
The function signatures for `find(id:)` and `update(id:)` are currently:
```swift
find<I: Identifier>(id: I, using db: Database? = nil, onCompletion: @escaping (I?, Self?, RequestError?) -> Void)
update<I: Identifier>(id: I, using db: Database?, _ onCompletion: @escaping (Identifier?, Self?, RequestError?) -> Void)
```
The `Identifier` in the completion handler is superfluous  - the calling code knows what it is already - and it additionally doesn't match the equivalent handler that you'd use with the Codable Routing API in Kitura, e.g.:
```swift
loadOneHandler(id: Int, completion: @escaping (Meal?, RequestError?) -> Void)
updateOneHandler(id: Int, meal: Meal, completion: @escaping (Meal?, RequestError?) -> Void)
```

This PR removes the Identifier from the completion handler so we can pass the one from the Codable Routing handler straight through.