### PR TITLE
add support for encoding and decoding Date and Date?

### DIFF
--- a/Sources/SwiftKueryORM/DatabaseDecoder.swift
+++ b/Sources/SwiftKueryORM/DatabaseDecoder.swift
@@ -191,6 +191,10 @@ open class DatabaseDecoder {
         let castValue = try castedValue(value, String.self, key)
         let uuid = UUID(uuidString: castValue)
         return try castedValue(uuid, type, key)
+      } else if type is Date.Type && value != nil {
+        let castValue = try castedValue(value, Double.self, key)
+        let date = Date(timeIntervalSinceReferenceDate: castValue)
+        return try castedValue(date, type, key)
       } else {
         throw RequestError(.ormDatabaseDecodingError, reason: "Unsupported type: \(String(describing: type)) for value: \(String(describing: value))")
       }
@@ -292,6 +296,10 @@ open class DatabaseDecoder {
         let castValue = try castedValue(value, String.self, key)
         let url = URL(string: castValue)
         return try castedValue(url, type, key)
+      } else if type is Date.Type {
+        let castValue = try castedValue(value, Double.self, key)
+        let date = Date(timeIntervalSinceReferenceDate: castValue)
+        return try castedValue(date, type, key)
       } else {
         throw RequestError(.ormDatabaseDecodingError, reason: "Unsupported type: \(String(describing: type)) for value: \(String(describing: value))")
       }

--- a/Sources/SwiftKueryORM/DatabaseEncoder.swift
+++ b/Sources/SwiftKueryORM/DatabaseEncoder.swift
@@ -64,6 +64,8 @@ fileprivate struct _DatabaseKeyedEncodingContainer<K: CodingKey> : KeyedEncoding
       encoder.values[key.stringValue] = urlValue.absoluteString
     } else if let uuidValue = value as? UUID {
       encoder.values[key.stringValue] = uuidValue.uuidString
+    } else if let dateValue = value as? Date {
+      encoder.values[key.stringValue] = dateValue.timeIntervalSinceReferenceDate
     } else if value is [Any] {
       throw RequestError(.ormDatabaseEncodingError, reason: "Encoding an array is not currently supported")
     } else if value is [AnyHashable: Any] {


### PR DESCRIPTION
I believe this adds support for persisting Date and Date? types using the ORM.
It is only tested against SQLite.

BTW. While writing this, I noticed that support was in place for UUID but not Optional<UUID>