### PR TITLE
Adding support for persisting RawRepresentable

### DIFF
--- a/Sources/SwiftKueryORM/DatabaseDecoder.swift
+++ b/Sources/SwiftKueryORM/DatabaseDecoder.swift
@@ -191,6 +191,10 @@ open class DatabaseDecoder {
         let castValue = try castedValue(value, String.self, key)
         let uuid = UUID(uuidString: castValue)
         return try castedValue(uuid, type, key)
+      } else if type is Date.Type && value != nil {
+        let castValue = try castedValue(value, Double.self, key)
+        let date = Date(timeIntervalSinceReferenceDate: castValue)
+        return try castedValue(date, type, key)
       } else {
         throw RequestError(.ormDatabaseDecodingError, reason: "Unsupported type: \(String(describing: type)) for value: \(String(describing: value))")
       }
@@ -292,6 +296,10 @@ open class DatabaseDecoder {
         let castValue = try castedValue(value, String.self, key)
         let url = URL(string: castValue)
         return try castedValue(url, type, key)
+      } else if type is Date.Type {
+        let castValue = try castedValue(value, Double.self, key)
+        let date = Date(timeIntervalSinceReferenceDate: castValue)
+        return try castedValue(date, type, key)
       } else {
         throw RequestError(.ormDatabaseDecodingError, reason: "Unsupported type: \(String(describing: type)) for value: \(String(describing: value))")
       }

--- a/Sources/SwiftKueryORM/DatabaseEncoder.swift
+++ b/Sources/SwiftKueryORM/DatabaseEncoder.swift
@@ -64,6 +64,8 @@ fileprivate struct _DatabaseKeyedEncodingContainer<K: CodingKey> : KeyedEncoding
       encoder.values[key.stringValue] = urlValue.absoluteString
     } else if let uuidValue = value as? UUID {
       encoder.values[key.stringValue] = uuidValue.uuidString
+    } else if let dateValue = value as? Date {
+      encoder.values[key.stringValue] = dateValue.timeIntervalSinceReferenceDate
     } else if value is [Any] {
       throw RequestError(.ormDatabaseEncodingError, reason: "Encoding an array is not currently supported")
     } else if value is [AnyHashable: Any] {

--- a/Sources/SwiftKueryORM/RawRepresentable+Codable.swift
+++ b/Sources/SwiftKueryORM/RawRepresentable+Codable.swift
@@ -1,0 +1,23 @@
+//
+//  RawRepresentable+Codable.swift
+//  SwiftKueryORM
+//
+//  Created by Jeremy Quinn on 05/06/2018.
+//
+
+import Foundation
+
+extension KeyedEncodingContainer {
+	public mutating func encodeIfPresent<T>(_ value: T?, forKey key: K) throws where T : Encodable & RawRepresentable, T.RawValue == Int {
+		try encodeIfPresent(value?.rawValue, forKey: key)
+	}
+}
+
+extension KeyedDecodingContainer {
+	public func decodeIfPresent<T>(_ type: T.Type, forKey key: K) throws -> T? where T : Decodable & RawRepresentable, T.RawValue == Int {
+		if let value = try decodeIfPresent(Int.self, forKey: key) {
+			return T.init(rawValue: value)
+		}
+		return nil
+	}
+}

--- a/Sources/SwiftKueryORM/RawRepresentable+Codable.swift
+++ b/Sources/SwiftKueryORM/RawRepresentable+Codable.swift
@@ -1,20 +1,49 @@
-//
-//  RawRepresentable+Codable.swift
-//  SwiftKueryORM
-//
-//  Created by Jeremy Quinn on 05/06/2018.
-//
+/**
+Copyright IBM Corporation 2018
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 
 import Foundation
 
+/// Support for encoding Codable & RawRepresentable enum for persistence in the ORM.
 extension KeyedEncodingContainer {
-	public mutating func encodeIfPresent<T>(_ value: T?, forKey key: K) throws where T : Encodable & RawRepresentable, T.RawValue == Int {
+
+	/// Database encode an enum which has the RawValue of String
+	internal mutating func encodeIfPresent<T>(_ value: T?, forKey key: K) throws where T : Encodable & RawRepresentable, T.RawValue == String {
+		try encodeIfPresent(value?.rawValue, forKey: key)
+	}
+
+	/// Database encode an enum which has the RawValue of Int
+	internal mutating func encodeIfPresent<T>(_ value: T?, forKey key: K) throws where T : Encodable & RawRepresentable, T.RawValue == Int {
 		try encodeIfPresent(value?.rawValue, forKey: key)
 	}
 }
 
+/// Support for decoding Codable & RawRepresentable enum for persistence in the ORM.
 extension KeyedDecodingContainer {
-	public func decodeIfPresent<T>(_ type: T.Type, forKey key: K) throws -> T? where T : Decodable & RawRepresentable, T.RawValue == Int {
+
+	/// Database decode an enum which has the RawValue of String
+	internal func decodeIfPresent<T>(_ type: T.Type, forKey key: K) throws -> T? where T : Decodable & RawRepresentable, T.RawValue == String {
+		if let value = try decodeIfPresent(String.self, forKey: key) {
+			return T.init(rawValue: value)
+		}
+		return nil
+	}
+
+	/// Database decode an enum which has the RawValue of Int
+	internal func decodeIfPresent<T>(_ type: T.Type, forKey key: K) throws -> T? where T : Decodable & RawRepresentable, T.RawValue == Int {
 		if let value = try decodeIfPresent(Int.self, forKey: key) {
 			return T.init(rawValue: value)
 		}


### PR DESCRIPTION
As requested, here is basic support for database encoding/decoding of `RawRepresentable` enum values.

Currently only two types are supported: `Int` and `String`.

While I beleive these are the most commonly used ones, it should be possible to support any type that is `Codable`.