### PR TITLE
 Prevent generation of unconnected database connections and set default timeout

### DIFF
--- a/Sources/SwiftKueryORM/Database.swift
+++ b/Sources/SwiftKueryORM/Database.swift
@@ -53,8 +53,14 @@ public class Database {
     /// Constructor for a single connection which becomes a connection pool
     public convenience init(single connection: Connection) {
         // Create single entry connection pool for thread safety
-        let singleConnectionPool = ConnectionPool(options: ConnectionPoolOptions(initialCapacity: 1, maxCapacity: 1),
-                                                  connectionGenerator: { connection },
+        let singleConnectionPool = ConnectionPool(options: ConnectionPoolOptions(initialCapacity: 1, maxCapacity: 1, timeout: 10),
+                                                  connectionGenerator: {
+                                                    connection.connect { _ in }
+                                                    if !connection.isConnected {
+                                                        return nil
+                                                    }
+                                                    return connection
+                                                    },
                                                   connectionReleaser: { _ in connection.closeConnection() })
         self.init(singleConnectionPool)
     }

--- a/Sources/SwiftKueryORM/Database.swift
+++ b/Sources/SwiftKueryORM/Database.swift
@@ -53,7 +53,7 @@ public class Database {
     /// Constructor for a single connection which becomes a connection pool
     public convenience init(single connection: Connection) {
         // Create single entry connection pool for thread safety
-        let singleConnectionPool = ConnectionPool(options: ConnectionPoolOptions(initialCapacity: 1, maxCapacity: 1, timeout: 10),
+        let singleConnectionPool = ConnectionPool(options: ConnectionPoolOptions(initialCapacity: 1, maxCapacity: 1, timeout: 10000),
                                                   connectionGenerator: {
                                                     connection.connect { _ in }
                                                     if !connection.isConnected {


### PR DESCRIPTION
This PR updates the ORM to prevent a case where when using a single connection to the database requests can be made without having explicitly connected.

It also sets a default timeout on the single connection pool to prevent appearing to hang indefinitely.