### PR TITLE
 Update Package.swift to use 2.0.0 of Swift-Kuery dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url:"https://github.com/IBM-Swift/Swift-Kuery.git", from: "1.3.0"),
+        .package(url:"https://github.com/IBM-Swift/Swift-Kuery.git", from: "2.0.0"),
         .package(url:"https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
         .package(url:"https://github.com/IBM-Swift/TypeDecoder.git", from: "1.0.0")
     ],

--- a/Tests/SwiftKueryORMTests/CommonUtils.swift
+++ b/Tests/SwiftKueryORMTests/CommonUtils.swift
@@ -39,7 +39,7 @@ class TestConnection: Connection {
         case returnValue
     }
 
-    init(result: Result, withDeleteRequiresUsing: Bool = false, withUpdateRequiresFrom: Bool = false, createAutoIncrement: ((String) -> String)? = nil) {
+    init(result: Result, withDeleteRequiresUsing: Bool = false, withUpdateRequiresFrom: Bool = false, createAutoIncrement: ((String, Bool) -> String)? = nil) {
         self.queryBuilder = QueryBuilder(withDeleteRequiresUsing: withDeleteRequiresUsing, withUpdateRequiresFrom: withUpdateRequiresFrom, createAutoIncrement: createAutoIncrement)
         self.result = result
     }
@@ -165,7 +165,7 @@ func createConnection(_ result: TestConnection.Result) -> TestConnection {
     return TestConnection(result: result)
 }
 
-func createConnection(withDeleteRequiresUsing: Bool = false, withUpdateRequiresFrom: Bool = false, createAutoIncrement: ((String) -> String)? = nil) -> TestConnection {
+func createConnection(withDeleteRequiresUsing: Bool = false, withUpdateRequiresFrom: Bool = false, createAutoIncrement: ((String, Bool) -> String)? = nil) -> TestConnection {
     return TestConnection(result: .returnEmpty, withDeleteRequiresUsing: withDeleteRequiresUsing, withUpdateRequiresFrom: withUpdateRequiresFrom, createAutoIncrement: createAutoIncrement)
 }
 

--- a/Tests/SwiftKueryORMTests/TestDelete.swift
+++ b/Tests/SwiftKueryORMTests/TestDelete.swift
@@ -30,7 +30,7 @@ class TestDelete: XCTestCase {
                 XCTAssertNil(error, "Delete Failed: \(String(describing: error))")
                 XCTAssertNotNil(connection.query, "Delete Failed: Query is nil")
                 if let query = connection.query {
-                  let expectedQuery = "DELETE FROM People WHERE People.id = ?1"
+                  let expectedQuery = "DELETE FROM \"People\" WHERE \"People\".\"id\" = ?1"
                   let resultQuery = connection.descriptionOf(query: query)
                   XCTAssertEqual(resultQuery, expectedQuery, "Expected query \(String(describing: expectedQuery)) did not match result query: \(String(describing: resultQuery))")
                 }
@@ -50,7 +50,7 @@ class TestDelete: XCTestCase {
                 XCTAssertNil(error, "Delete Failed: \(String(describing: error))")
                 XCTAssertNotNil(connection.query, "Delete Failed: Query is nil")
                 if let query = connection.query {
-                  let expectedQuery = "DELETE FROM People"
+                  let expectedQuery = "DELETE FROM \"People\""
                   let resultQuery = connection.descriptionOf(query: query)
                   XCTAssertEqual(resultQuery, expectedQuery, "Expected query \(String(describing: expectedQuery)) did not match result query: \(String(describing: resultQuery))")
                 }
@@ -76,8 +76,8 @@ class TestDelete: XCTestCase {
                 XCTAssertNil(error, "Delete Failed: \(String(describing: error))")
                 XCTAssertNotNil(connection.query, "Delete Failed: Query is nil")
                 if let query = connection.query {
-                  let expectedPrefix = "DELETE FROM People WHERE"
-                  let expectedClauses = [["People.name = ?1", "People.name = ?2"], ["People.age = ?1", "People.age = ?2"]]
+                  let expectedPrefix = "DELETE FROM \"People\" WHERE"
+                  let expectedClauses = [["\"People\".\"name\" = ?1", "\"People\".\"name\" = ?2"], ["\"People\".\"age\" = ?1", "\"People\".\"age\" = ?2"]]
                   let expectedOperator = "AND"
                   let resultQuery = connection.descriptionOf(query: query)
                   XCTAssertTrue(resultQuery.hasPrefix(expectedPrefix))

--- a/Tests/SwiftKueryORMTests/TestFind.swift
+++ b/Tests/SwiftKueryORMTests/TestFind.swift
@@ -31,7 +31,7 @@ class TestFind: XCTestCase {
                 XCTAssertNil(error, "Find Failed: \(String(describing: error))")
                 XCTAssertNotNil(connection.query, "Find Failed: Query is nil")
                 if let query = connection.query {
-                  let expectedQuery = "SELECT * FROM People WHERE People.id = ?1"
+                  let expectedQuery = "SELECT * FROM \"People\" WHERE \"People\".\"id\" = ?1"
                   let resultQuery = connection.descriptionOf(query: query)
                   XCTAssertEqual(resultQuery, expectedQuery, "Find Failed: Invalid query")
                 }
@@ -57,7 +57,7 @@ class TestFind: XCTestCase {
                 XCTAssertNil(error, "Find Failed: \(String(describing: error))")
                 XCTAssertNotNil(connection.query, "Find Failed: Query is nil")
                 if let query = connection.query {
-                  let expectedQuery = "SELECT * FROM People"
+                  let expectedQuery = "SELECT * FROM \"People\""
                   let resultQuery = connection.descriptionOf(query: query)
                   XCTAssertEqual(resultQuery, expectedQuery, "Find Failed: Invalid query")
                 }
@@ -88,8 +88,8 @@ class TestFind: XCTestCase {
                 XCTAssertNil(error, "Find Failed: \(String(describing: error))")
                 XCTAssertNotNil(connection.query, "Find Failed: Query is nil")
                 if let query = connection.query {
-                  let expectedPrefix = "SELECT * FROM People WHERE"
-                  let expectedClauses = [["People.name = ?1", "People.name = ?2"], ["People.age = ?1", "People.age = ?2"]]
+                  let expectedPrefix = "SELECT * FROM \"People\" WHERE"
+                  let expectedClauses = [["\"People\".\"name\" = ?1", "\"People\".\"name\" = ?2"], ["\"People\".\"age\" = ?1", "\"People\".\"age\" = ?2"]]
                   let expectedOperator = "AND"
                   let resultQuery = connection.descriptionOf(query: query)
                   XCTAssertTrue(resultQuery.hasPrefix(expectedPrefix))

--- a/Tests/SwiftKueryORMTests/TestId.swift
+++ b/Tests/SwiftKueryORMTests/TestId.swift
@@ -36,7 +36,7 @@ class TestId: XCTestCase {
                 XCTAssertNil(error, "Find Failed: \(String(describing: error))")
                 XCTAssertNotNil(connection.query, "Find Failed: Query is nil")
                 if let query = connection.query {
-                  let expectedQuery = "SELECT * FROM People WHERE People.name = ?1"
+                  let expectedQuery = "SELECT * FROM \"People\" WHERE \"People\".\"name\" = ?1"
                   let resultQuery = connection.descriptionOf(query: query)
                   XCTAssertEqual(resultQuery, expectedQuery, "Find Failed: Invalid query")
                 }
@@ -62,9 +62,9 @@ class TestId: XCTestCase {
                 XCTAssertNil(error, "Update Failed: \(String(describing: error))")
                 XCTAssertNotNil(connection.query, "Update Failed: Query is nil")
                 if let query = connection.query {
-                  let expectedPrefix = "UPDATE People SET"
-                  let expectedSuffix = "WHERE People.name = ?3"
-                  let expectedUpdates = [["name = ?1", "name = ?2"], ["age = ?1", "age = ?2"]]
+                  let expectedPrefix = "UPDATE \"People\" SET"
+                  let expectedSuffix = "WHERE \"People\".\"name\" = ?3"
+                  let expectedUpdates = [["\"name\" = ?1", "\"name\" = ?2"], ["\"age\" = ?1", "\"age\" = ?2"]]
                   let resultQuery = connection.descriptionOf(query: query)
                   XCTAssertTrue(resultQuery.hasPrefix(expectedPrefix))
                   XCTAssertTrue(resultQuery.hasSuffix(expectedSuffix))
@@ -97,7 +97,7 @@ class TestId: XCTestCase {
                 XCTAssertNil(error, "Delete Failed: \(String(describing: error))")
                 XCTAssertNotNil(connection.query, "Delete Failed: Query is nil")
                 if let query = connection.query {
-                  let expectedQuery = "DELETE FROM People WHERE People.name = ?1"
+                  let expectedQuery = "DELETE FROM \"People\" WHERE \"People\".\"name\" = ?1"
                   let resultQuery = connection.descriptionOf(query: query)
                   XCTAssertEqual(resultQuery, expectedQuery, "Expected query \(String(describing: expectedQuery)) did not match result query: \(String(describing: resultQuery))")
                 }

--- a/Tests/SwiftKueryORMTests/TestSave.swift
+++ b/Tests/SwiftKueryORMTests/TestSave.swift
@@ -62,9 +62,9 @@ class TestSave: XCTestCase {
                 XCTAssertNil(error, "Save Failed: \(String(describing: error))")
                 XCTAssertNotNil(connection.query, "Save Failed: Query is nil")
                 if let query = connection.query {
-                  let expectedPrefix = "INSERT INTO People"
+                  let expectedPrefix = "INSERT INTO \"People\""
                   let expectedSQLStatement = "VALUES"
-                  let expectedDictionary = ["name": "?1,?2", "age": "?1,?2"]
+                  let expectedDictionary = ["\"name\"": "?1,?2", "\"age\"": "?1,?2"]
 
                   let resultQuery = connection.descriptionOf(query: query)
                   XCTAssertTrue(resultQuery.hasPrefix(expectedPrefix))
@@ -94,9 +94,9 @@ class TestSave: XCTestCase {
                 XCTAssertNil(error, "Save Failed: \(String(describing: error))")
                 XCTAssertNotNil(connection.query, "Save Failed: Query is nil")
                 if let query = connection.query {
-                  let expectedPrefix = "INSERT INTO People"
+                  let expectedPrefix = "INSERT INTO \"People\""
                   let expectedSQLStatement = "VALUES"
-                  let expectedDictionary = ["name": "?1,?2", "age": "?1,?2"]
+                  let expectedDictionary = ["\"name\"": "?1,?2", "\"age\"": "?1,?2"]
 
                   let resultQuery = connection.descriptionOf(query: query)
                   XCTAssertTrue(resultQuery.hasPrefix(expectedPrefix))

--- a/Tests/SwiftKueryORMTests/TestTable.swift
+++ b/Tests/SwiftKueryORMTests/TestTable.swift
@@ -30,7 +30,7 @@ class TestTable: XCTestCase {
                 XCTAssertNil(error, "Table Creation Failed: \(String(describing: error))")
                 XCTAssertNotNil(connection.raw, "Table Creation Failed: Query is nil")
                 if let raw = connection.raw {
-                  let expectedQuery = "CREATE TABLE Users (username text NOT NULL, password text NOT NULL, id bigint AUTO_INCREMENT PRIMARY KEY)"
+                  let expectedQuery = "CREATE TABLE \"Users\" (\"username\" text NOT NULL, \"password\" text NOT NULL, \"id\" bigint AUTO_INCREMENT PRIMARY KEY)"
                   XCTAssertEqual(raw, expectedQuery, "Table Creation Failed: Invalid query")
                 }
                 expectation.fulfill()
@@ -49,7 +49,7 @@ class TestTable: XCTestCase {
                 XCTAssertNil(error, "Table Drop Failed: \(String(describing: error))")
                 XCTAssertNotNil(connection.query, "Table Drop Failed: Query is nil")
                 if let query = connection.query {
-                  let expectedQuery = "DROP TABLE Users"
+                  let expectedQuery = "DROP TABLE \"Users\""
                   let resultQuery = connection.descriptionOf(query: query)
                   XCTAssertEqual(resultQuery, expectedQuery, "Table Drop Failed: Invalid query")
                 }
@@ -75,7 +75,7 @@ class TestTable: XCTestCase {
                 XCTAssertNil(error, "Table Creation Failed: \(String(describing: error))")
                 XCTAssertNotNil(connection.raw, "Table Creation Failed: Query is nil")
                 if let raw = connection.raw {
-                  let expectedQuery = "CREATE TABLE Meals (name text PRIMARY KEY NOT NULL, rating bigint NOT NULL)"
+                  let expectedQuery = "CREATE TABLE \"Meals\" (\"name\" text PRIMARY KEY NOT NULL, \"rating\" bigint NOT NULL)"
                   XCTAssertEqual(raw, expectedQuery, "Table Creation Failed: Invalid query")
                 }
                 expectation.fulfill()
@@ -101,7 +101,7 @@ class TestTable: XCTestCase {
                 XCTAssertNil(error, "Table Creation Failed: \(String(describing: error))")
                 XCTAssertNotNil(connection.raw, "Table Creation Failed: Query is nil")
                 if let raw = connection.raw {
-                  let expectedQuery = "CREATE TABLE Grades (grade double NOT NULL, course text NOT NULL, MyId integer AUTO_INCREMENT PRIMARY KEY)"
+                  let expectedQuery = "CREATE TABLE \"Grades\" (\"grade\" double NOT NULL, \"course\" text NOT NULL, \"MyId\" integer AUTO_INCREMENT PRIMARY KEY)"
                   XCTAssertEqual(raw, expectedQuery, "Table Creation Failed: Invalid query")
                 }
                 expectation.fulfill()

--- a/Tests/SwiftKueryORMTests/TestUpdate.swift
+++ b/Tests/SwiftKueryORMTests/TestUpdate.swift
@@ -29,9 +29,9 @@ class TestUpdate: XCTestCase {
                 XCTAssertNil(error, "Update Failed: \(String(describing: error))")
                 XCTAssertNotNil(connection.query, "Update Failed: Query is nil")
                 if let query = connection.query {
-                  let expectedPrefix = "UPDATE People SET"
-                  let expectedSuffix = "WHERE People.id = ?3"
-                  let expectedUpdates = [["name = ?1", "name = ?2"], ["age = ?1", "age = ?2"]]
+                  let expectedPrefix = "UPDATE \"People\" SET"
+                  let expectedSuffix = "WHERE \"People\".\"id\" = ?3"
+                  let expectedUpdates = [["\"name\" = ?1", "\"name\" = ?2"], ["\"age\" = ?1", "\"age\" = ?2"]]
                   let resultQuery = connection.descriptionOf(query: query)
                   XCTAssertTrue(resultQuery.hasPrefix(expectedPrefix))
                   XCTAssertTrue(resultQuery.hasSuffix(expectedSuffix))


### PR DESCRIPTION
This commit updates the version of Swift-Kuery package dependcy to 2.0.0.
The Swift-Kuery-PostgreSQL version 1.2.0 requires this version.
Previously, the Swift package manager just hangs on updating/fetching the packages when using a plugin's version 1.2.0.

```
Package.swift
...
      .package(url: "https://github.com/IBM-Swift/Swift-Kuery-ORM.git", from: "0.2.0"),
      .package(url: "https://github.com/IBM-Swift/Swift-Kuery-PostgreSQL.git", from: "1.2.0"),
...

```

```
$ swift --version
Apple Swift version 4.1.2 (swiftlang-902.0.54 clang-902.0.39.2)
Target: x86_64-apple-darwin17.6.0
```

This commit should fix the inconsistency between the Swift-Kuery-ORM's package dependency version and its plugins which is already using Swift-Kuery 2.0 at versions >= 1.2.0.

Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>