### PR TITLE
Execute query

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,34 +224,34 @@ Grade.deleteAll { error in
 
 ### Customizing your Model
 
-The ORM defines an extension to `Model` which provides a number of `public static executeQuery(…)` functions. These methods can be used to create custom functions within your model’s that perform more complex database operations. The example below defines and Info type and adds a custom method to it that will retrieve all database records which have an age over 20:
+The ORM defines an extension to `Model` which provides a number of `public static executeQuery(…)` functions. These functions can be used to create custom functions within your model that perform more complex database operations. The example below defines a Person model and with a custom function that will retrieve all  records which have age > 20:
 
 ```swift
-// define the info struct
-struct Info: Codable {
+// define the Person struct
+struct Person: Codable {
     var firstname: String
     var surname: String
     var age: Int
 }
 
-// extend Info to conform to model and add overTwenties function
-extension Info: Model {
+// extend Person to conform to model and add overTwenties function
+extension Person: Model {
 
-    // Define a synchronous function to retrieve all record of Info with age > 20
-    public static func getOverTwenties() -> [Info]? {
+    // Define a synchronous function to retrieve all records of Person with age > 20
+    public static func getOverTwenties() -> [Person]? {
         let wait = DispatchSemaphore(value: 0)
         // First get the table
         var table: Table
         do {
-            table = try Info.getTable()
+            table = try Person.getTable()
         } catch {
             // Handle error
         }
         // Define result, query and execute
-        var overTwenties: [Info]? = nil
+        var overTwenties: [Person]? = nil
         let query = Select(from: table).where("age > 20")
 
-        Info.executeQuery(query: query, parameters: nil) { results, error in
+        Person.executeQuery(query: query, parameters: nil) { results, error in
             guard let results = results else {
                 // Handle error
             }
@@ -267,21 +267,21 @@ extension Info: Model {
 
 Alternatively you can define and asynchronous getOverTwenties function:
 ```swift
-public static func getOverTwenties(oncompletion: @escaping ([Info]?, RequestError?)-> Void) {
+public static func getOverTwenties(oncompletion: @escaping ([Person]?, RequestError?)-> Void) {
     var table: Table
     do {
-        table = try Info.getTable()
+        table = try Person.getTable()
     } catch {
         // Handle error
     }
     let query = Select(from: table).where("age > 20")
-    Info.executeQuery(query: query, parameters: nil, oncompletion)
+    Person.executeQuery(query: query, parameters: nil, oncompletion)
 }
 ```
 
 which can be called in a fashion similar to the following:
 ```swift
-Info.getOverTwenties() { result, error in
+Person.getOverTwenties() { result, error in
     guard let result = result else {
         // Handle error
     }

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -349,7 +349,7 @@ public extension Model {
         Self.executeQuery(query: query, parameters: parameters, using: db, onCompletion)
     }
 
-    internal func executeQuery(query: Query, parameters: [Any?], using db: Database? = nil, _ onCompletion: @escaping (Self?, RequestError?) -> Void ) {
+    private func executeQuery(query: Query, parameters: [Any?], using db: Database? = nil, _ onCompletion: @escaping (Self?, RequestError?) -> Void ) {
         Self.executeTask() { connection, error in
             guard let connection = connection else {
                 guard let error = error else {
@@ -372,7 +372,7 @@ public extension Model {
         }
     }
 
-    internal func executeQuery<I: Identifier>(query: Query, parameters: [Any?], using db: Database? = nil, _ onCompletion: @escaping (I?, Self?, RequestError?) -> Void ) {
+    private func executeQuery<I: Identifier>(query: Query, parameters: [Any?], using db: Database? = nil, _ onCompletion: @escaping (I?, Self?, RequestError?) -> Void ) {
         Self.executeTask() { connection, error in
             guard let connection = connection else {
                 guard let error = error else {
@@ -422,7 +422,7 @@ public extension Model {
         }
     }
 
-    internal static func executeQuery(query: Query, parameters: [Any?], using db: Database? = nil, _ onCompletion: @escaping (Self?, RequestError?) -> Void ) {
+    public static func executeQuery(query: Query, parameters: [Any?], using db: Database? = nil, _ onCompletion: @escaping (Self?, RequestError?) -> Void ) {
         Self.executeTask() { connection, error in
             guard let connection = connection else {
                 guard let error = error else {
@@ -462,7 +462,7 @@ public extension Model {
         }
     }
 
-    internal static func executeQuery<I: Identifier>(query: Query, parameters: [Any?], using db: Database? = nil, _ onCompletion: @escaping (I?, Self?, RequestError?) -> Void ) {
+    public static func executeQuery<I: Identifier>(query: Query, parameters: [Any?], using db: Database? = nil, _ onCompletion: @escaping (I?, Self?, RequestError?) -> Void ) {
         Self.executeTask() { connection, error in
             guard let connection = connection else {
                 guard let error = error else {
@@ -522,7 +522,7 @@ public extension Model {
 
     /// - Parameter using: Optional Database to use
     /// - Returns: A tuple ([Model], RequestError)
-    internal static func executeQuery(query: Query, parameters: [Any?]? = nil, using db: Database? = nil, _ onCompletion: @escaping ([Self]?, RequestError?)-> Void ) {
+    public static func executeQuery(query: Query, parameters: [Any?]? = nil, using db: Database? = nil, _ onCompletion: @escaping ([Self]?, RequestError?)-> Void ) {
         Self.executeTask() { connection, error in
             guard let connection = connection else {
                 guard let error = error else {
@@ -584,7 +584,7 @@ public extension Model {
 
     /// - Parameter using: Optional Database to use
     /// - Returns: A tuple ([Model], RequestError)
-    internal static func executeQuery<I: Identifier>(query: Query, parameters: [Any?]? = nil, using db: Database? = nil, _ onCompletion: @escaping ([(I, Self)]?, RequestError?) -> Void ) {
+    public static func executeQuery<I: Identifier>(query: Query, parameters: [Any?]? = nil, using db: Database? = nil, _ onCompletion: @escaping ([(I, Self)]?, RequestError?) -> Void ) {
         Self.executeTask() { connection, error in
             guard let connection = connection else {
                 guard let error = error else {
@@ -661,7 +661,7 @@ public extension Model {
     /// - Parameter using: Optional Database to use
     /// - Returns: An optional RequestError
 
-    internal static func executeQuery(query: Query, parameters: [Any?]? = nil, using db: Database? = nil, _ onCompletion: @escaping (RequestError?) -> Void ) {
+    public static func executeQuery(query: Query, parameters: [Any?]? = nil, using db: Database? = nil, _ onCompletion: @escaping (RequestError?) -> Void ) {
         Self.executeTask() { connection, error in
             guard let connection = connection else {
                 guard let error = error else {

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -426,7 +426,7 @@ public extension Model {
     /// - Parameter query: The `Query` to execute
     /// - Parameter parameters: An optional array of parameters to pass to the query
     /// - Parameter using: Optional Database to use
-    /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed a tuple containing an optional `Self` and optional `RequestError`. On successful execution the `Self` will be non-nil and error nil, otherwise the `Self` will be nil and error non-nil.
+    /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed a tuple of (Self?, RequestError?), of which one will be nil, depending on whether the query was successful.
     public static func executeQuery(query: Query, parameters: [Any?], using db: Database? = nil, _ onCompletion: @escaping (Self?, RequestError?) -> Void ) {
         Self.executeTask() { connection, error in
             guard let connection = connection else {
@@ -471,7 +471,7 @@ public extension Model {
     /// - Parameter query: The `Query` to execute
     /// - Parameter parameters: An optional array of parameters to pass to the query
     /// - Parameter using: Optional Database to use
-    /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed a tuple containing an `Identifier`, an optional `Self` and optional `RequestError`. On successful execution the `Identifier` and `Self` will be non-nil and error nil, otherwise the `Identifier` and `Self` will be nil and error non-nil.
+    /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed a tuple of (Identifier?, Self?, RequestError?), of which some will be nil, depending on whether the query was successful.
     public static func executeQuery<I: Identifier>(query: Query, parameters: [Any?], using db: Database? = nil, _ onCompletion: @escaping (I?, Self?, RequestError?) -> Void ) {
         Self.executeTask() { connection, error in
             guard let connection = connection else {
@@ -534,7 +534,7 @@ public extension Model {
     /// - Parameter query: The `Query` to execute
     /// - Parameter parameters: An optional array of parameters to pass to the query
     /// - Parameter using: Optional Database to use
-    /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed a tuple containing an optional array of `Self` and optional `RequestError`. On successful execution the arry will be non-nil and error nil, otherwise the array will be nil and error non-nil.
+    /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed a tuple of ([Self]?, RequestError?), of which one will be nil, depending on whether the query was successful.
     public static func executeQuery(query: Query, parameters: [Any?]? = nil, using db: Database? = nil, _ onCompletion: @escaping ([Self]?, RequestError?)-> Void ) {
         Self.executeTask() { connection, error in
             guard let connection = connection else {
@@ -599,7 +599,7 @@ public extension Model {
     /// - Parameter query: The `Query` to execute
     /// - Parameter parameters: An optional array of parameters to pass to the query
     /// - Parameter using: Optional Database to use
-    /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed a tuple containing an optional array of tuples containing an `Identifier` and `Self` and optional `RequestError`. On successful execution the arry will be non-nil and error nil, otherwise the array will be nil and error non-nil.
+    /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed a tuple of ([Identifier, Self]?, RequestError?), of which one will be nil, depending on whether the query was successful.
     public static func executeQuery<I: Identifier>(query: Query, parameters: [Any?]? = nil, using db: Database? = nil, _ onCompletion: @escaping ([(I, Self)]?, RequestError?) -> Void ) {
         Self.executeTask() { connection, error in
             guard let connection = connection else {
@@ -678,7 +678,7 @@ public extension Model {
     /// - Parameter query: The `Query` to execute
     /// - Parameter parameters: An optional array of parameters to pass to the query
     /// - Parameter using: Optional Database to use
-    /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed an optional `RequestError`. On successful execution the error will be nil, otherwise the error will be non-nil.
+    /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed a RequestError? which may be nil, depending on whether the query was successful.
     public static func executeQuery(query: Query, parameters: [Any?]? = nil, using db: Database? = nil, _ onCompletion: @escaping (RequestError?) -> Void ) {
         Self.executeTask() { connection, error in
             guard let connection = connection else {

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -422,6 +422,11 @@ public extension Model {
         }
     }
 
+    /// Allows custom functions on a model to query the database directly.
+    /// - Parameter query: The `Query` to execute
+    /// - Parameter parameters: An optional array of parameters to pass to the query
+    /// - Parameter using: Optional Database to use
+    /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed a tuple containing an optional `Self` and optional `RequestError`. On successful execution the `Self` will be non-nil and error nil, otherwise the `Self` will be nil and error non-nil.
     public static func executeQuery(query: Query, parameters: [Any?], using db: Database? = nil, _ onCompletion: @escaping (Self?, RequestError?) -> Void ) {
         Self.executeTask() { connection, error in
             guard let connection = connection else {
@@ -462,6 +467,11 @@ public extension Model {
         }
     }
 
+    /// Allows custom functions on a model to query the database directly.
+    /// - Parameter query: The `Query` to execute
+    /// - Parameter parameters: An optional array of parameters to pass to the query
+    /// - Parameter using: Optional Database to use
+    /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed a tuple containing an `Identifier`, an optional `Self` and optional `RequestError`. On successful execution the `Identifier` and `Self` will be non-nil and error nil, otherwise the `Identifier` and `Self` will be nil and error non-nil.
     public static func executeQuery<I: Identifier>(query: Query, parameters: [Any?], using db: Database? = nil, _ onCompletion: @escaping (I?, Self?, RequestError?) -> Void ) {
         Self.executeTask() { connection, error in
             guard let connection = connection else {
@@ -520,8 +530,11 @@ public extension Model {
         }
     }
 
+    /// Allows custom functions on a model to query the database directly.
+    /// - Parameter query: The `Query` to execute
+    /// - Parameter parameters: An optional array of parameters to pass to the query
     /// - Parameter using: Optional Database to use
-    /// - Returns: A tuple ([Model], RequestError)
+    /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed a tuple containing an optional array of `Self` and optional `RequestError`. On successful execution the arry will be non-nil and error nil, otherwise the array will be nil and error non-nil.
     public static func executeQuery(query: Query, parameters: [Any?]? = nil, using db: Database? = nil, _ onCompletion: @escaping ([Self]?, RequestError?)-> Void ) {
         Self.executeTask() { connection, error in
             guard let connection = connection else {
@@ -582,8 +595,11 @@ public extension Model {
         }
     }
 
+    /// Allows custom functions on a model to query the database directly.
+    /// - Parameter query: The `Query` to execute
+    /// - Parameter parameters: An optional array of parameters to pass to the query
     /// - Parameter using: Optional Database to use
-    /// - Returns: A tuple ([Model], RequestError)
+    /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed a tuple containing an optional array of tuples containing an `Identifier` and `Self` and optional `RequestError`. On successful execution the arry will be non-nil and error nil, otherwise the array will be nil and error non-nil.
     public static func executeQuery<I: Identifier>(query: Query, parameters: [Any?]? = nil, using db: Database? = nil, _ onCompletion: @escaping ([(I, Self)]?, RequestError?) -> Void ) {
         Self.executeTask() { connection, error in
             guard let connection = connection else {
@@ -658,9 +674,11 @@ public extension Model {
         }
     }
 
+    /// Allows custom functions on a model to query the database directly.
+    /// - Parameter query: The `Query` to execute
+    /// - Parameter parameters: An optional array of parameters to pass to the query
     /// - Parameter using: Optional Database to use
-    /// - Returns: An optional RequestError
-
+    /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed an optional `RequestError`. On successful execution the error will be nil, otherwise the error will be non-nil.
     public static func executeQuery(query: Query, parameters: [Any?]? = nil, using db: Database? = nil, _ onCompletion: @escaping (RequestError?) -> Void ) {
         Self.executeTask() { connection, error in
             guard let connection = connection else {


### PR DESCRIPTION
This PR adjusts the access modifiers on the executeQuery functions to allow them to be used as intended. It also adds a better example of model customization to the README.