### PR TITLE
fix: Prevent error when using camel case properties

### DIFF
--- a/Sources/SwiftKueryORM/DatabaseDecoder.swift
+++ b/Sources/SwiftKueryORM/DatabaseDecoder.swift
@@ -75,7 +75,7 @@ open class DatabaseDecoder {
 
         /// Check that value exists in the data return from the database
         private func checkValueExitence(_ key: Key) throws -> Any? {
-            let keyName = key.stringValue.lowercased()
+            let keyName = key.stringValue
             guard let value = decoder.values[keyName] else {
                 throw DecodingError.keyNotFound(key, DecodingError.Context(
                     codingPath: [key],

--- a/Tests/SwiftKueryORMTests/TestFind.swift
+++ b/Tests/SwiftKueryORMTests/TestFind.swift
@@ -113,4 +113,35 @@ class TestFind: XCTestCase {
             }
         })
     }
+
+    struct Order: Model {
+        static var tableName = "Orders"
+        var item: Int
+        var deliveryAddress: String
+    }
+
+    /**
+     Testing that a Model can be decoded if it contains camel case property name.
+     */
+    func testCamelCaseProperty() {
+        let connection: TestConnection = createConnection(.returnOneOrder)
+        Database.default = Database(single: connection)
+        performTest(asyncTasks: { expectation in
+            Order.findAll { array, error in
+                XCTAssertNil(error, "Find Failed: \(String(describing: error))")
+                XCTAssertNotNil(connection.query, "Find Failed: Query is nil")
+                if let query = connection.query {
+                    let expectedQuery = "SELECT * FROM \"Orders\""
+                    let resultQuery = connection.descriptionOf(query: query)
+                    XCTAssertEqual(resultQuery, expectedQuery, "Find Failed: Invalid query")
+                }
+                XCTAssertNotNil(array, "Find Failed: No array of models returned")
+                if let array = array {
+                    XCTAssertEqual(array.count, 1, "Find Failed: \(String(describing: array.count)) is not equal to 3")
+                }
+                expectation.fulfill()
+            }
+        })
+    }
+
 }


### PR DESCRIPTION
This PR resolves an error that occurs when using camel case properties in Model declarations.

The issue was introduced with the changes in SwiftKuery to respect casing when converting `a Table` property to a `Column`.

The fix simply removes the lower casing of decoding keys as the database now returns camel cased titles as opposed to the previously lower case titles.

The PR also adds a test to ensure that Models containing camel case properties can be successfully decoded.