### PR TITLE
Changes how date encoding and decoding works

### DIFF
--- a/Sources/SwiftKueryORM/DatabaseDecoder.swift
+++ b/Sources/SwiftKueryORM/DatabaseDecoder.swift
@@ -192,9 +192,8 @@ open class DatabaseDecoder {
                 let uuid = UUID(uuidString: castValue)
                 return try castedValue(uuid, type, key)
             } else if type is Date.Type && value != nil {
-                let castValue = try castedValue(value, Double.self, key)
-                let date = Date(timeIntervalSinceReferenceDate: castValue)
-                return try castedValue(date, type, key)
+                let castValue = try castedValue(value, Date.self, key)
+                return try castedValue(castValue, type, key)
             } else {
                 throw RequestError(.ormDatabaseDecodingError, reason: "Unsupported type: \(String(describing: type)) for value: \(String(describing: value))")
             }

--- a/Sources/SwiftKueryORM/DatabaseEncoder.swift
+++ b/Sources/SwiftKueryORM/DatabaseEncoder.swift
@@ -65,7 +65,7 @@ fileprivate struct _DatabaseKeyedEncodingContainer<K: CodingKey> : KeyedEncoding
         } else if let uuidValue = value as? UUID {
             encoder.values[key.stringValue] = uuidValue.uuidString
         } else if let dateValue = value as? Date {
-            encoder.values[key.stringValue] = dateValue.timeIntervalSinceReferenceDate
+            encoder.values[key.stringValue] = dateValue
         } else if value is [Any] {
             throw RequestError(.ormDatabaseEncodingError, reason: "Encoding an array is not currently supported")
         } else if value is [AnyHashable: Any] {


### PR DESCRIPTION
I could not get the date encoding and decoding to work with MySQL as is (converting to double), and using `timeIntervalSinceReferenceDate`. 

I'm unaware if these are breaking changes for other databases, but there were 0 failures after the changes. 

I'd like to propose these changes, in order to get ORM working with MySQL, and will happily take feedback if this needs to be reworked to work with other databases.