### PR TITLE
Support optional id fields

### DIFF
--- a/Sources/SwiftKueryORM/TableInfo.swift
+++ b/Sources/SwiftKueryORM/TableInfo.swift
@@ -84,7 +84,12 @@ public class TableInfo {
         }
         if let SQLType = valueType as? SQLDataType.Type {
           if key == idColumn.name && !idColumnIsSet {
-            columns.append(Column(key, SQLType, primaryKey: true, notNull: !optionalBool))
+            // If this is an optional id field create an autoincrementing column
+            if optionalBool {
+                columns.append(Column(key, SQLType, autoIncrement: true, primaryKey: true))
+            } else {
+                columns.append(Column(key, SQLType, primaryKey: true, notNull: !optionalBool))
+            }
             idColumnIsSet = true
           } else {
             columns.append(Column(key, SQLType, notNull: !optionalBool))


### PR DESCRIPTION
This PR adds support for optional id fields withing models.

When a user creates an optional id field the ORM will create an auto-increment column in the database table.

If an instance is saved with a nil id then the database will auto-increment. If the instance specifies an id the database will use the specified id.