### PR TITLE
Add support for optional id fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,108 @@ Person.getOverTwenties() { result, error in
 
 If you'd like to learn more about how you can customize queries, check out the [Swift-Kuery](https://github.com/IBM-Swift/Swift-Kuery) repository for more information.
 
+## Model Identifiers
+
+The ORM has several options available for identifying an instance of a model.
+
+### Automatic id assignment
+
+If your `Model` is defined without specifying an id field using the `idColumnName` property or the default name of `id` then the ORM will create an auto incrementing column named `id` in the database table for the `Model`, eg.
+
+```swift
+struct Person: Model {
+    var firstname: String
+    var surname: String
+    var age: Int
+}
+```
+ 
+As the model does not contain a field for the id you cannot access it directly from an instance of your model. The ORM provides a specific `save` API that will return the instances id. It is important to note the ORM will not link the returned id to the instance of the Model in any way, the user is required to maintain this relationship if it is important for the application behaviour. Below is an example of retrieving an id for an instance of `Person` as defined above:
+
+```swift
+let person = Person(firstname: "example", surname: "person", age: 21)
+person.save() { (id: Int?, person: Person?, error: RequestError?) in
+    guard let id = id, let person = person else{
+        // Handle error
+        return
+    }
+    // Use person and id
+}
+```
+
+### Manual id assignment
+
+You can add an id field to your model and manage the assignment of id’s yourself by either specifying a property name for your id field using the `idColumnName` property or by defining a field named `id`, which is the default name for the aforementioned property. For example:
+
+```swift
+struct Person: Model {
+    var myIDField: Int
+    var firstname: String
+    var surname: String
+    var age: Int
+
+    static var idColumnName = "myIDField"
+    static var idColumnType = Int.self
+}
+```
+
+When using a `Model` defined in this way all the id management is the responsibility of the user. An example of saving an instance of this Person is below:
+
+```swift
+let person = Person(myIDField: 1, firstname: "example", surname: "person", age: 21)
+person.save() { person, error in
+    guard let person = person else{
+        // Handle error
+        return
+    }
+    // Use newly saved person
+}
+```
+
+### Using `optional` if fields
+
+If you would like an id field that allows you to specify specific values whilst also being automatic when an id is not explicitly set you can use an optional type for your id field, this requires an implementation of the `getID` and `setID` functions. For example:
+
+```swift
+struct Person: Model {
+    var id: Int?
+    var firstname: String
+    var surname: String
+    var age: Int
+
+    mutating func setID(to value: String) {
+        self.id = Int(value)
+    }
+
+    func getID() -> Any? {
+        return id
+    }
+}
+```
+
+When saving an instance of this `Person` you can either set a specific value for `id` or set `id` to `nil`, for example:
+
+```swift
+let person = Person(id: nil, firstname: “Banana”, surname: “Man”, age: 21)
+let otherPerson = Person(id: 5, firstname: “Super”, surname: “Ted”, age: 26)
+
+person.save() { savedPerson, error in
+        guard let newPerson = savedPerson else {
+            // Handle error
+        }
+        print(newPerson.id) // Prints the next value in the databases identifier sequence, for the first save this will be 1
+}
+
+otherPerson.save() { savedPerson, error in
+        guard let newOtherPerson = savedPerson else {
+            // Handle error
+        }
+        print(newOtherPerson.id) // Prints 5
+}
+```
+
+**NOTE** - When using manual or option id fields you need to ensure that the application is written to handle violation of unique identifier constraints which will occur if you attempt to save a model with an id that already exists in the database.
+
 ## List of plugins
 
 * [PostgreSQL](https://github.com/IBM-Swift/Swift-Kuery-PostgreSQL)

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -29,7 +29,7 @@ public protocol Model: Codable {
     static var idColumnType: SQLDataType.Type {get}
 
     /// Defines whether the Model embeds its id
-    var embeddedID: Bool {get}
+    static var embeddedID: Bool {get}
 
     /// Call to create the table in the database synchronously
     static func createTableSync(using db: Database?) throws -> Bool
@@ -119,14 +119,10 @@ public extension Model {
     static var idColumnType: SQLDataType.Type { return Int64.self }
 
     /// Defaults to "false"
-    var embeddedID: Bool { return false }
+    static var embeddedID: Bool { return false }
 
     mutating func setID(to value: String) {
         return
-    }
-
-    func getID() -> Any? {
-        return nil
     }
 
     private static func executeTask(using db: Database? = nil, task: @escaping ((Connection?, QueryError?) -> ())) {
@@ -251,7 +247,7 @@ public extension Model {
         let columns = table.columns.filter({values[$0.name] != nil})
         let parameters: [Any?] = columns.map({values[$0.name]!})
         let parameterPlaceHolders: [Parameter] = parameters.map {_ in return Parameter()}
-        let query = Insert(into: table, columns: columns, values: parameterPlaceHolders, returnID: self.embeddedID)
+        let query = Insert(into: table, columns: columns, values: parameterPlaceHolders, returnID: type(of: self).embeddedID)
         self.executeQuery(query: query, parameters: parameters, using: db, onCompletion)
     }
 

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -95,6 +95,7 @@ public protocol Model: Codable {
     /// handler. The callback is passed a dictionary [id: model] or an error
     static func findAll<Q: QueryParams, I: Identifier>(using db: Database?, matching queryParams: Q?, _ onCompletion: @escaping ([I: Self]?, RequestError?) -> Void)
 
+    mutating func setID(to value: String)
 }
 
 public extension Model {
@@ -111,6 +112,10 @@ public extension Model {
     static var idColumnName: String { return "id" }
     /// Defaults to Int64
     static var idColumnType: SQLDataType.Type { return Int64.self }
+
+    mutating func setID(to value: String) {
+        return
+    }
 
     private static func executeTask(using db: Database? = nil, task: @escaping ((Connection?, QueryError?) -> ())) {
         guard let database = db ?? Database.default else {
@@ -234,7 +239,9 @@ public extension Model {
         let columns = table.columns.filter({$0.autoIncrement != true && values[$0.name] != nil})
         let parameters: [Any?] = columns.map({values[$0.name]!})
         let parameterPlaceHolders: [Parameter] = parameters.map {_ in return Parameter()}
-        let query = Insert(into: table, columns: columns, values: parameterPlaceHolders)
+        let autoIncrementColumn = table.columns.filter { $0.isPrimaryKey && $0.autoIncrement }
+        let returnId = autoIncrementColumn.isEmpty ? false : true
+        let query = Insert(into: table, columns: columns, values: parameterPlaceHolders, returnID: returnId)
         self.executeQuery(query: query, parameters: parameters, using: db, onCompletion)
     }
 
@@ -350,6 +357,7 @@ public extension Model {
     }
 
     private func executeQuery(query: Query, parameters: [Any?], using db: Database? = nil, _ onCompletion: @escaping (Self?, RequestError?) -> Void ) {
+        var dictionaryTitleToValue = [String: Any?]()
         Self.executeTask() { connection, error in
             guard let connection = connection else {
                 guard let error = error else {
@@ -367,7 +375,32 @@ public extension Model {
                     return
                 }
 
-                onCompletion(self, nil)
+                if let insertQuery = query as? Insert, insertQuery.returnID {
+                    result.asRows() { rows, error in
+                        guard let rows = rows, rows.count > 0 else {
+                            onCompletion(nil, RequestError(.ormNotFound, reason: "Could not retrieve value for Query: \(String(describing: query))"))
+                            return
+                        }
+
+                        dictionaryTitleToValue = rows[0]
+
+                        guard let value = dictionaryTitleToValue[Self.idColumnName] else {
+                            onCompletion(nil, RequestError(.ormNotFound, reason: "Could not find return id"))
+                            return
+                        }
+
+                        guard let unwrappedValue: Any = value else {
+                            onCompletion(nil, RequestError(.ormNotFound, reason: "Return id is nil"))
+                            return
+                        }
+
+                        var newSelf = self
+                        newSelf.setID(to: String(describing: unwrappedValue))
+
+                        return onCompletion(newSelf, nil)
+                    }
+                }
+                return onCompletion(self, nil)
             }
         }
     }

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -123,7 +123,7 @@ public extension Model {
         return
     }
 
-    private func getID() -> Any? {
+    func getID() -> Any? {
         return nil
     }
 

--- a/Sources/SwiftKueryORM/TableInfo.swift
+++ b/Sources/SwiftKueryORM/TableInfo.swift
@@ -91,7 +91,12 @@ public class TableInfo {
                 }
                 if let SQLType = valueType as? SQLDataType.Type {
                     if key == idColumn.name && !idColumnIsSet {
-                        columns.append(Column(key, SQLType, primaryKey: true, notNull: !optionalBool))
+                        // If this is an optional id field create an autoincrementing column
+                        if optionalBool {
+                            columns.append(Column(key, SQLType, autoIncrement: true, primaryKey: true))
+                        } else {
+                            columns.append(Column(key, SQLType, primaryKey: true, notNull: !optionalBool))
+                        }
                         idColumnIsSet = true
                     } else {
                         columns.append(Column(key, SQLType, notNull: !optionalBool))

--- a/Tests/SwiftKueryORMTests/TestSave.swift
+++ b/Tests/SwiftKueryORMTests/TestSave.swift
@@ -54,7 +54,7 @@ class TestSave: XCTestCase {
       Testing that the correct SQL Query is created to save a Model
     */
     func testSave() {
-        let connection: TestConnection = createConnection()
+        let connection: TestConnection = createConnection(.returnOneRow)
         Database.default = Database(single: connection)
         performTest(asyncTasks: { expectation in
             let person = Person(name: "Joe", age: 38)

--- a/Tests/SwiftKueryORMTests/TestSave.swift
+++ b/Tests/SwiftKueryORMTests/TestSave.swift
@@ -54,7 +54,7 @@ class TestSave: XCTestCase {
       Testing that the correct SQL Query is created to save a Model
     */
     func testSave() {
-        let connection: TestConnection = createConnection(.returnOneRow)
+        let connection: TestConnection = createConnection()
         Database.default = Database(single: connection)
         performTest(asyncTasks: { expectation in
             let person = Person(name: "Joe", age: 38)


### PR DESCRIPTION
This PR adds support for optional id fields within a model.

The Model protocol has two functions added with default implementations, `getID` and `setID`. The former of these is used to determine whether the `Model` instance has a non-nil id property. The latter is used to set the value of the id property if it is set by the database. The README has been updated with usage instructions.



