### PR TITLE
Add support for optional Int `id` properties to `Model`

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,9 +295,9 @@ If you'd like to learn more about how you can customize queries, check out the [
 
 The ORM has several options available for identifying an instance of a model.
 
-### Automatic id assignment
+### Automatic ID assignment
 
-If you define your `Model` without specifying an id field, either using the `idColumnName` property or the default name of `id`, then the ORM will create an auto incrementing column named `id` in the database table for the `Model`, eg.
+If you define your `Model` without specifying an ID property, either by using the `idColumnName` property or the default name of `id`, then the ORM will create an auto-incrementing column named `id` in the database table for the model, eg.
 
 ```swift
 struct Person: Model {
@@ -307,11 +307,11 @@ struct Person: Model {
 }
 ```
  
-As the model does not contain a field for the id you cannot access it directly from an instance of your model. The ORM provides a specific `save` API that will return the instances id. It is important to note the ORM will not link the returned id to the instance of the Model in any way, the user is required to maintain this relationship if it is important for the application behaviour. Below is an example of retrieving an id for an instance of `Person` as defined above:
+The model does not contain a property for the ID. The ORM provides a specific `save` API that will return the ID that was assigned. It is important to note the ORM will not link the returned ID to the instance of the Model in any way; you are responsible for maintaining this relationship if necessary. Below is an example of retrieving an ID for an instance of the `Person` model defined above:
 
 ```swift
 let person = Person(firstname: "example", surname: "person", age: 21)
-person.save() { (id: Int?, person: Person?, error: RequestError?) in
+person.save() { (id: Int?, person, error) in
     guard let id = id, let person = person else{
         // Handle error
         return
@@ -319,10 +319,11 @@ person.save() { (id: Int?, person: Person?, error: RequestError?) in
     // Use person and id
 }
 ```
+The compiler requires you to declare the type of the ID received by your completion handler; the type should be `Int?` for an ID that has been automatically assigned.
 
-### Manual id assignment
+### Manual ID assignment
 
-You can add an id field to your model and manage the assignment of ids yourself by either specifying a property name for your id field using the `idColumnName` property or by defining a field named `id`, which is the default name for the aforementioned property. For example:
+You can manage the assignment of IDs yourself by adding an `id` property to your model. You may customise the name of this property by defining `idColumnName`. For example:
 
 ```swift
 struct Person: Model {
@@ -336,12 +337,12 @@ struct Person: Model {
 }
 ```
 
-When using a `Model` defined in this way all the id management is the responsibility of the user. An example of saving an instance of this Person is below:
+When using a `Model` defined in this way, you are responsible for the assignment and management of IDs. Below is an example of saving an instance of the `Person` model defined above:
 
 ```swift
 let person = Person(myIDField: 1, firstname: "example", surname: "person", age: 21)
-person.save() { person, error in
-    guard let person = person else{
+person.save() { (person, error) in
+    guard let person = person else {
         // Handle error
         return
     }
@@ -349,9 +350,13 @@ person.save() { person, error in
 }
 ```
 
-### Using `optional` id fields
+### Using `optional` ID properties
 
-If you would like an id field that allows you to specify specific values, whilst also being automatic when an id is not explicitly set, you can use an optional Int for your id field and define the `idKeypath` property to point at the field. Your definition must include the type `IDKeyPath` as in the example below:
+Declaring your ID property as optional allows the ORM to assign the ID automatically when the model is saved. If the value of ID is `nil`, the database will assign an auto-incremented value. At present this is only support for an `Int?` type.
+
+You may instead provide an explicit value, which will be used instead of automatic assignment.
+
+Optional IDs must be identified by defining the `idKeypath: IDKeyPath` property, as in the example below:
 
 ```swift
 struct Person: Model {
@@ -364,30 +369,30 @@ struct Person: Model {
 }
 ```
 
-In the above example the `Model` is defined with an ID field matching the default `idColumnName` property, should you wish to use an alternative name you need to re-define `idColumnName` accordingly. The `optional` id field is limited to the `Int` type.
+In the example above, the `Model` is defined with an ID property matching the default `idColumnName` value, but should you wish to use an alternative name you must define `idColumnName` accordingly.
 
-When saving an instance of this `Person` you can either set a specific value for `id` or set `id` to `nil`, for example:
+Below is an example of saving an instance of the `Person` defined above, both with an explicitly defined ID and without:
 
 ```swift
 let person = Person(id: nil, firstname: “Banana”, surname: “Man”, age: 21)
-let otherPerson = Person(id: 5, firstname: “Super”, surname: “Ted”, age: 26)
+let specificPerson = Person(id: 5, firstname: “Super”, surname: “Ted”, age: 26)
 
-person.save() { savedPerson, error in
+person.save() { (savedPerson, error) in
         guard let newPerson = savedPerson else {
             // Handle error
         }
-        print(newPerson.id) // Prints the next value in the databases identifier sequence, for the first save this will be 1
+        print(newPerson.id) // Prints the next value in the databases identifier sequence, eg. 1
 }
 
-otherPerson.save() { savedPerson, error in
-        guard let newOtherPerson = savedPerson else {
+specificPerson.save() { (savedPerson, error) in
+        guard let newPerson = savedPerson else {
             // Handle error
         }
-        print(newOtherPerson.id) // Prints 5
+        print(newPerson.id) // Prints 5
 }
 ```
 
-**NOTE** - When using manual or option id fields you need to ensure that the application is written to handle violation of unique identifier constraints which will occur if you attempt to save a model with an id that already exists in the database. If you are using `SwiftKueryPostgreSQL` this error can occur when saving with a `nil` value for the id property due to the way PostgreSQL implements `autoincrement` behaviour (it assigns ids from a sequence and does not skip the next auto assiged value forward when a manual id insert is made).
+**NOTE** - When using manual or optional ID properties, you should be prepared to handle violation of unique identifier constraints. These can occur if you attempt to save a model with an ID that already exists, or in the case of Postgres, if the auto-incremented value collides with an ID that was previously inserted explicitly.
 
 ## List of plugins
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ The ORM has several options available for identifying an instance of a model.
 
 ### Automatic id assignment
 
-If your `Model` is defined without specifying an id field using the `idColumnName` property or the default name of `id` then the ORM will create an auto incrementing column named `id` in the database table for the `Model`, eg.
+If you define your `Model` without specifying an id field, either using the `idColumnName` property or the default name of `id`, then the ORM will create an auto incrementing column named `id` in the database table for the `Model`, eg.
 
 ```swift
 struct Person: Model {
@@ -322,7 +322,7 @@ person.save() { (id: Int?, person: Person?, error: RequestError?) in
 
 ### Manual id assignment
 
-You can add an id field to your model and manage the assignment of id’s yourself by either specifying a property name for your id field using the `idColumnName` property or by defining a field named `id`, which is the default name for the aforementioned property. For example:
+You can add an id field to your model and manage the assignment of ids yourself by either specifying a property name for your id field using the `idColumnName` property or by defining a field named `id`, which is the default name for the aforementioned property. For example:
 
 ```swift
 struct Person: Model {
@@ -351,7 +351,7 @@ person.save() { person, error in
 
 ### Using `optional` id fields
 
-If you would like an id field that allows you to specify specific values whilst also being automatic when an id is not explicitly set you can use an optional Int for your id field and re-define the `idKeypath` property to point at the field. `IDKeyPath` is a typealias for `WritableKeyPath<Self, Int?>?`, your re-definition must be explicity set this type. For example:
+If you would like an id field that allows you to specify specific values, whilst also being automatic when an id is not explicitly set, you can use an optional Int for your id field and define the `idKeypath` property to point at the field. Your definition must include the type `IDKeyPath` as in the example below:
 
 ```swift
 struct Person: Model {
@@ -387,8 +387,7 @@ otherPerson.save() { savedPerson, error in
 }
 ```
 
-**NOTE** - When using manual or option id fields you need to ensure that the application is written to handle violation of unique identifier constraints which will occur if you attempt to save a model with an id that already exists in the database. If you are using `SwiftKueryPostgreSQL` this error can occur when savinf with a `nil` value for the id property due to the way PostgreSQL implements `autoincrement` behaviour.
-
+**NOTE** - When using manual or option id fields you need to ensure that the application is written to handle violation of unique identifier constraints which will occur if you attempt to save a model with an id that already exists in the database. If you are using `SwiftKueryPostgreSQL` this error can occur when saving with a `nil` value for the id property due to the way PostgreSQL implements `autoincrement` behaviour (it assigns ids from a sequence and does not skip the next auto assiged value forward when a manual id insert is made).
 
 ## List of plugins
 

--- a/README.md
+++ b/README.md
@@ -349,9 +349,9 @@ person.save() { person, error in
 }
 ```
 
-### Using `optional` if fields
+### Using `optional` id fields
 
-If you would like an id field that allows you to specify specific values whilst also being automatic when an id is not explicitly set you can use an optional Int for your id field and re-define the `idKeypath` property to point at the field. For example:
+If you would like an id field that allows you to specify specific values whilst also being automatic when an id is not explicitly set you can use an optional Int for your id field and re-define the `idKeypath` property to point at the field. `IDKeyPath` is a typealias for `WritableKeyPath<Self, Int?>?`, your re-definition must be explicity set this type. For example:
 
 ```swift
 struct Person: Model {
@@ -360,7 +360,7 @@ struct Person: Model {
     var surname: String
     var age: Int
 
-    static var idKeyPath: WritableKeyPath<Person, Int?>? = \Person.id
+    static var idKeyPath: IDKeyPath = \Person.id
 }
 ```
 

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -753,7 +753,8 @@ public extension Model {
     }
 
     static func getTable() throws -> Table {
-        return try Database.tableInfo.getTable((Self.idColumnName, Self.idColumnType), Self.tableName, for: Self.self)
+        let idKeyPathSet: Bool = Self.idKeypath != nil
+        return try Database.tableInfo.getTable((Self.idColumnName, Self.idColumnType, idKeyPathSet), Self.tableName, for: Self.self)
     }
 
     /**

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -28,8 +28,11 @@ public protocol Model: Codable {
     /// Defines the id column type in the Database
     static var idColumnType: SQLDataType.Type {get}
 
+    /// Defines typealias for the id fields keypath
+    typealias IDKeyPath = WritableKeyPath<Self, Int?>?
+
     /// Defines the keypath to the Models id field
-    static var idKeypath: WritableKeyPath<Self, Int?>? {get}
+    static var idKeypath: IDKeyPath {get}
 
     /// Call to create the table in the database synchronously
     static func createTableSync(using db: Database?) throws -> Bool
@@ -115,7 +118,7 @@ public extension Model {
     /// Defaults to Int64
     static var idColumnType: SQLDataType.Type { return Int64.self }
 
-    static var idKeypath: WritableKeyPath<Any, Int?>? { return nil }
+    static var idKeypath: IDKeyPath { return nil }
 
     private static func executeTask(using db: Database? = nil, task: @escaping ((Connection?, QueryError?) -> ())) {
         guard let database = db ?? Database.default else {

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -28,6 +28,9 @@ public protocol Model: Codable {
     /// Defines the id column type in the Database
     static var idColumnType: SQLDataType.Type {get}
 
+    /// Defines the keypath to the Models id field
+    static var idKeypath: WritableKeyPath<Self, Int?>? {get}
+
     /// Call to create the table in the database synchronously
     static func createTableSync(using db: Database?) throws -> Bool
 
@@ -111,6 +114,8 @@ public extension Model {
     static var idColumnName: String { return "id" }
     /// Defaults to Int64
     static var idColumnType: SQLDataType.Type { return Int64.self }
+
+    static var idKeypath: WritableKeyPath<Any, Int?>? { return nil }
 
     private static func executeTask(using db: Database? = nil, task: @escaping ((Connection?, QueryError?) -> ())) {
         guard let database = db ?? Database.default else {
@@ -231,10 +236,11 @@ public extension Model {
             return
         }
 
-        let columns = table.columns.filter({$0.autoIncrement != true && values[$0.name] != nil})
+        let columns = table.columns.filter({values[$0.name] != nil})
         let parameters: [Any?] = columns.map({values[$0.name]!})
         let parameterPlaceHolders: [Parameter] = parameters.map {_ in return Parameter()}
-        let query = Insert(into: table, columns: columns, values: parameterPlaceHolders)
+        let returnID: Bool = Self.idKeypath != nil
+        let query = Insert(into: table, columns: columns, values: parameterPlaceHolders, returnID: returnID)
         self.executeQuery(query: query, parameters: parameters, using: db, onCompletion)
     }
 
@@ -350,6 +356,7 @@ public extension Model {
     }
 
     private func executeQuery(query: Query, parameters: [Any?], using db: Database? = nil, _ onCompletion: @escaping (Self?, RequestError?) -> Void ) {
+        var dictionaryTitleToValue = [String: Any?]()
         Self.executeTask() { connection, error in
             guard let connection = connection else {
                 guard let error = error else {
@@ -366,8 +373,43 @@ public extension Model {
                     onCompletion(nil, Self.convertError(error))
                     return
                 }
+                if let insertQuery = query as? Insert, insertQuery.returnID {
+                    result.asRows() { rows, error in
+                        guard let rows = rows, rows.count > 0 else {
+                            onCompletion(nil, RequestError(.ormNotFound, reason: "Could not retrieve value for Query: \(String(describing: query))"))
+                            return
+                        }
 
-                onCompletion(self, nil)
+                        dictionaryTitleToValue = rows[0]
+
+                        guard let value = dictionaryTitleToValue[Self.idColumnName] else {
+                            onCompletion(nil, RequestError(.ormNotFound, reason: "Could not find return id"))
+                            return
+                        }
+
+                        guard let unwrappedValue: Any = value else {
+                            onCompletion(nil, RequestError(.ormNotFound, reason: "Return id is nil"))
+                            return
+                        }
+
+                        guard let idKeyPath = Self.idKeypath else {
+                            // We should not be here if keypath is nil
+                            return onCompletion(nil, RequestError(.ormInternalError, reason: "id Keypath is nil"))
+                        }
+                        var newValue: Int? = nil
+                        do {
+                            newValue = try Int(value: String(describing: unwrappedValue))
+                        } catch {
+                            return onCompletion(nil, RequestError(.ormInternalError, reason: "Unable to convert identifier"))
+                        }
+                        var newSelf = self
+                        newSelf[keyPath: idKeyPath] = newValue
+
+                        return onCompletion(newSelf, nil)
+                    }
+                } else {
+                    return onCompletion(self, nil)
+                }
             }
         }
     }

--- a/Sources/SwiftKueryORM/TableInfo.swift
+++ b/Sources/SwiftKueryORM/TableInfo.swift
@@ -29,11 +29,11 @@ public class TableInfo {
     private var codableMapQueue = DispatchQueue(label: "codableMap.queue", attributes: .concurrent)
 
     /// Get the table for a model
-    func getTable<T: Decodable>(_ idColumn: (name: String, type: SQLDataType.Type), _ tableName: String, for type: T.Type) throws -> Table {
+    func getTable<T: Decodable>(_ idColumn: (name: String, type: SQLDataType.Type, idKeyPathSet: Bool), _ tableName: String, for type: T.Type) throws -> Table {
         return try getInfo(idColumn, tableName, type).table
     }
 
-    func getInfo<T: Decodable>(_ idColumn: (name: String, type: SQLDataType.Type), _ tableName: String, _ type: T.Type) throws -> (info: TypeInfo, table: Table) {
+    func getInfo<T: Decodable>(_ idColumn: (name: String, type: SQLDataType.Type, idKeyPathSet: Bool), _ tableName: String, _ type: T.Type) throws -> (info: TypeInfo, table: Table) {
         let typeString = "\(type)"
         var result: (TypeInfo, Table)? = nil
         // Read from codableMap when no concurrent write is occurring
@@ -57,7 +57,7 @@ public class TableInfo {
     }
 
     /// Construct the table for a Model
-    func constructTable(_ idColumn: (name: String, type: SQLDataType.Type), _ tableName: String, _ typeInfo: TypeInfo) throws -> Table {
+    func constructTable(_ idColumn: (name: String, type: SQLDataType.Type, idKeyPathSet: Bool), _ tableName: String, _ typeInfo: TypeInfo) throws -> Table {
         var columns: [Column] = []
         var idColumnIsSet = false
         switch typeInfo {
@@ -92,7 +92,7 @@ public class TableInfo {
                 if let SQLType = valueType as? SQLDataType.Type {
                     if key == idColumn.name && !idColumnIsSet {
                         // If this is an optional id field create an autoincrementing column
-                        if optionalBool {
+                        if optionalBool && idColumn.idKeyPathSet {
                             columns.append(Column(key, SQLType, autoIncrement: true, primaryKey: true))
                         } else {
                             columns.append(Column(key, SQLType, primaryKey: true, notNull: !optionalBool))

--- a/Sources/SwiftKueryORM/TableInfo.swift
+++ b/Sources/SwiftKueryORM/TableInfo.swift
@@ -91,7 +91,12 @@ public class TableInfo {
                 }
                 if let SQLType = valueType as? SQLDataType.Type {
                     if key == idColumn.name && !idColumnIsSet {
-                        columns.append(Column(key, SQLType, primaryKey: true, notNull: !optionalBool))
+                        // If this is an optional id field create an autoincrementing column
+                        if optionalBool {
+                            columns.append(Column(key, SQLType, autoIncrement: true, primaryKey: true))
+                        } else {
+                            columns.append(Column(key, SQLType, primaryKey: true, notNull: !optionalBool))
+                        }
                         idColumnIsSet = true
                     } else {
                         columns.append(Column(key, SQLType, notNull: !optionalBool))

--- a/Tests/SwiftKueryORMTests/TestId.swift
+++ b/Tests/SwiftKueryORMTests/TestId.swift
@@ -105,4 +105,28 @@ class TestId: XCTestCase {
             }
         })
     }
+
+    struct IdentifiedPerson: Model {
+        static var tableName = "People"
+        static var idKeypath: IDKeyPath = \IdentifiedPerson.id
+
+        var id: Int?
+        var name: String
+        var age: Int
+    }
+
+    func testNilIDInsert() {
+        let connection: TestConnection = createConnection(.returnOneRow) //[1, "Joe", Int32(38)]
+        Database.default = Database(single: connection)
+        performTest(asyncTasks: { expectation in
+            let myIPerson = IdentifiedPerson(id: nil, name: "Joe", age: 38)
+            myIPerson.save() { identifiedPerson, error in
+                XCTAssertNil(error, "Error on IdentifiedPerson.save")
+                if let newPerson = identifiedPerson {
+                    XCTAssertEqual(newPerson.id, 1, "Id not stored on IdentifiedPerson")
+                }
+                expectation.fulfill()
+            }
+        })
+    }
 }

--- a/Tests/SwiftKueryORMTests/TestId.swift
+++ b/Tests/SwiftKueryORMTests/TestId.swift
@@ -144,11 +144,12 @@ class TestId: XCTestCase {
         let connection: TestConnection = createConnection(.returnOneRow) //[1, "Joe", Int32(38)]
         Database.default = Database(single: connection)
         performTest(asyncTasks: { expectation in
-            let myIPerson = NonAutoIDPerson(id: nil, name: "Joe", age: 38)
-            myIPerson.save() { identifiedPerson, error in
-                XCTAssertNil(error, "Error on IdentifiedPerson.save")
-                if let newPerson = identifiedPerson {
-                    XCTAssertEqual(newPerson.id, nil, "Id stored on NonAutoIDPerson")
+            NonAutoIDPerson.createTable { result, error in
+                XCTAssertNil(error, "Table Creation Failed: \(String(describing: error))")
+                XCTAssertNotNil(connection.raw, "Table Creation Failed: Query is nil")
+                if let raw = connection.raw {
+                    let expectedQuery = "CREATE TABLE \"People\" (\"id\" type PRIMARY KEY, \"name\" type NOT NULL, \"age\" type NOT NULL)"
+                    XCTAssertEqual(raw, expectedQuery, "Table Creation Failed: Invalid query")
                 }
                 expectation.fulfill()
             }

--- a/Tests/SwiftKueryORMTests/TestId.swift
+++ b/Tests/SwiftKueryORMTests/TestId.swift
@@ -10,6 +10,8 @@ class TestId: XCTestCase {
             ("testFind", testFind),
             ("testUpdate", testUpdate),
             ("testDelete", testDelete),
+            ("testNilIDInsert", testNilIDInsert),
+            ("testNonAutoNilIDInsert", testNonAutoNilIDInsert),
         ]
     }
 
@@ -124,6 +126,29 @@ class TestId: XCTestCase {
                 XCTAssertNil(error, "Error on IdentifiedPerson.save")
                 if let newPerson = identifiedPerson {
                     XCTAssertEqual(newPerson.id, 1, "Id not stored on IdentifiedPerson")
+                }
+                expectation.fulfill()
+            }
+        })
+    }
+
+    struct NonAutoIDPerson: Model {
+        static var tableName = "People"
+
+        var id: Int?
+        var name: String
+        var age: Int
+    }
+
+    func testNonAutoNilIDInsert() {
+        let connection: TestConnection = createConnection(.returnOneRow) //[1, "Joe", Int32(38)]
+        Database.default = Database(single: connection)
+        performTest(asyncTasks: { expectation in
+            let myIPerson = NonAutoIDPerson(id: nil, name: "Joe", age: 38)
+            myIPerson.save() { identifiedPerson, error in
+                XCTAssertNil(error, "Error on IdentifiedPerson.save")
+                if let newPerson = identifiedPerson {
+                    XCTAssertEqual(newPerson.id, nil, "Id stored on NonAutoIDPerson")
                 }
                 expectation.fulfill()
             }


### PR DESCRIPTION
This PR adds support for optional Integer `id` properties to the `Model` protocol.

The README has been updated accordingly.