### PR TITLE
Ensure a provided db is used to execute Model operations

### DIFF
--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -149,7 +149,7 @@ public extension Model {
         } catch let error {
             return onCompletion(nil, Self.convertError(error))
         }
-        Self.executeTask() { connection, error in
+        Self.executeTask(using: db) { connection, error in
             guard let connection = connection else {
                 guard let error = error else {
                     return onCompletion(nil, RequestError(.ormInternalError, reason: "Unknow error when getting connection"))
@@ -199,7 +199,7 @@ public extension Model {
         } catch let error {
             return onCompletion(nil, Self.convertError(error))
         }
-        Self.executeTask() { connection, error in
+        Self.executeTask(using: db) { connection, error in
             guard let connection = connection else {
                 guard let error = error else {
                     return onCompletion(nil, RequestError(.ormInternalError, reason: "Unknow error when getting connection"))
@@ -350,7 +350,7 @@ public extension Model {
     }
 
     private func executeQuery(query: Query, parameters: [Any?], using db: Database? = nil, _ onCompletion: @escaping (Self?, RequestError?) -> Void ) {
-        Self.executeTask() { connection, error in
+        Self.executeTask(using: db) { connection, error in
             guard let connection = connection else {
                 guard let error = error else {
                     return onCompletion(nil, RequestError(.ormInternalError, reason: "Unknow error when getting connection"))
@@ -373,7 +373,7 @@ public extension Model {
     }
 
     private func executeQuery<I: Identifier>(query: Query, parameters: [Any?], using db: Database? = nil, _ onCompletion: @escaping (I?, Self?, RequestError?) -> Void ) {
-        Self.executeTask() { connection, error in
+        Self.executeTask(using: db) { connection, error in
             guard let connection = connection else {
                 guard let error = error else {
                     return onCompletion(nil, nil, RequestError(.ormInternalError, reason: "Unknow error when getting connection"))
@@ -428,7 +428,7 @@ public extension Model {
     /// - Parameter using: Optional Database to use
     /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed a tuple of (Self?, RequestError?), of which one will be nil, depending on whether the query was successful.
     public static func executeQuery(query: Query, parameters: [Any?], using db: Database? = nil, _ onCompletion: @escaping (Self?, RequestError?) -> Void ) {
-        Self.executeTask() { connection, error in
+        Self.executeTask(using: db) { connection, error in
             guard let connection = connection else {
                 guard let error = error else {
                     return onCompletion(nil, RequestError(.ormInternalError, reason: "Unknow error when getting connection"))
@@ -473,7 +473,7 @@ public extension Model {
     /// - Parameter using: Optional Database to use
     /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed a tuple of (Identifier?, Self?, RequestError?), of which some will be nil, depending on whether the query was successful.
     public static func executeQuery<I: Identifier>(query: Query, parameters: [Any?], using db: Database? = nil, _ onCompletion: @escaping (I?, Self?, RequestError?) -> Void ) {
-        Self.executeTask() { connection, error in
+        Self.executeTask(using: db) { connection, error in
             guard let connection = connection else {
                 guard let error = error else {
                     return onCompletion(nil, nil, RequestError(.ormInternalError, reason: "Unknow error when getting connection"))
@@ -536,7 +536,7 @@ public extension Model {
     /// - Parameter using: Optional Database to use
     /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed a tuple of ([Self]?, RequestError?), of which one will be nil, depending on whether the query was successful.
     public static func executeQuery(query: Query, parameters: [Any?]? = nil, using db: Database? = nil, _ onCompletion: @escaping ([Self]?, RequestError?)-> Void ) {
-        Self.executeTask() { connection, error in
+        Self.executeTask(using: db) { connection, error in
             guard let connection = connection else {
                 guard let error = error else {
                     return onCompletion(nil, RequestError(.ormInternalError, reason: "Unknow error when getting connection"))
@@ -601,7 +601,7 @@ public extension Model {
     /// - Parameter using: Optional Database to use
     /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed a tuple of ([Identifier, Self]?, RequestError?), of which one will be nil, depending on whether the query was successful.
     public static func executeQuery<I: Identifier>(query: Query, parameters: [Any?]? = nil, using db: Database? = nil, _ onCompletion: @escaping ([(I, Self)]?, RequestError?) -> Void ) {
-        Self.executeTask() { connection, error in
+        Self.executeTask(using: db) { connection, error in
             guard let connection = connection else {
                 guard let error = error else {
                     return onCompletion(nil, RequestError(.ormInternalError, reason: "Unknow error when getting connection"))
@@ -680,7 +680,7 @@ public extension Model {
     /// - Parameter using: Optional Database to use
     /// - Parameter onCompletion: The function to be called when the execution of the query has completed. The function will be passed a RequestError? which may be nil, depending on whether the query was successful.
     public static func executeQuery(query: Query, parameters: [Any?]? = nil, using db: Database? = nil, _ onCompletion: @escaping (RequestError?) -> Void ) {
-        Self.executeTask() { connection, error in
+        Self.executeTask(using: db) { connection, error in
             guard let connection = connection else {
                 guard let error = error else {
                     return onCompletion(RequestError(.ormInternalError, reason: "Unknow error when getting connection"))

--- a/Tests/SwiftKueryORMTests/TestFind.swift
+++ b/Tests/SwiftKueryORMTests/TestFind.swift
@@ -46,6 +46,32 @@ class TestFind: XCTestCase {
     }
 
     /**
+     Testing that the correct SQL Query is created to retrieve a specific model when using a non-default database.
+     Testing that the model can be retrieved
+     */
+    func testFindUsingDB() {
+        let connection: TestConnection = createConnection(.returnOneRow)
+        let db = Database(single: connection)
+        performTest(asyncTasks: { expectation in
+            Person.find(id: 1, using: db) { p, error in
+                XCTAssertNil(error, "Find Failed: \(String(describing: error))")
+                XCTAssertNotNil(connection.query, "Find Failed: Query is nil")
+                if let query = connection.query {
+                    let expectedQuery = "SELECT * FROM \"People\" WHERE \"People\".\"id\" = ?1"
+                    let resultQuery = connection.descriptionOf(query: query)
+                    XCTAssertEqual(resultQuery, expectedQuery, "Find Failed: Invalid query")
+                }
+                XCTAssertNotNil(p, "Find Failed: No model returned")
+                if let p = p {
+                    XCTAssertEqual(p.name, "Joe", "Find Failed: \(String(describing: p.name)) is not equal to Joe")
+                    XCTAssertEqual(p.age, 38, "Find Failed: \(String(describing: p.age)) is not equal to 38")
+                }
+                expectation.fulfill()
+            }
+        })
+    }
+
+    /**
       Testing that the correct SQL Query is created to retrieve all the models.
       Testing that correct amount of models are retrieved
     */

--- a/Tests/SwiftKueryORMTests/TestTable.swift
+++ b/Tests/SwiftKueryORMTests/TestTable.swift
@@ -39,6 +39,25 @@ class TestTable: XCTestCase {
     }
 
     /**
+     Testing that the correct SQL Query is created to create a table when using a non-default database
+     */
+    func testCreateTableUsingDB() {
+        let connection: TestConnection = createConnection(.returnEmpty)
+        let db = Database(single: connection)
+        performTest(asyncTasks: { expectation in
+            User.createTable(using: db) { result, error in
+                XCTAssertNil(error, "Table Creation Failed: \(String(describing: error))")
+                XCTAssertNotNil(connection.raw, "Table Creation Failed: Query is nil")
+                if let raw = connection.raw {
+                    let expectedQuery = "CREATE TABLE \"Users\" (\"username\" type NOT NULL, \"password\" type NOT NULL, \"id\" type AUTO_INCREMENT PRIMARY KEY)"
+                    XCTAssertEqual(raw, expectedQuery, "Table Creation Failed: Invalid query")
+                }
+                expectation.fulfill()
+            }
+        })
+    }
+
+    /**
       Testing that the correct SQL Query is created to drop a table
     */
     func testDropTable() {
@@ -52,6 +71,26 @@ class TestTable: XCTestCase {
                   let expectedQuery = "DROP TABLE \"Users\""
                   let resultQuery = connection.descriptionOf(query: query)
                   XCTAssertEqual(resultQuery, expectedQuery, "Table Drop Failed: Invalid query")
+                }
+                expectation.fulfill()
+            }
+        })
+    }
+
+    /**
+     Testing that the correct SQL Query is created to drop a table when using a non-default database
+     */
+    func testDropTableUsingDB() {
+        let connection: TestConnection = createConnection(.returnEmpty)
+        let db = Database(single: connection)
+        performTest(asyncTasks: { expectation in
+            User.dropTable(using: db) { result, error in
+                XCTAssertNil(error, "Table Drop Failed: \(String(describing: error))")
+                XCTAssertNotNil(connection.query, "Table Drop Failed: Query is nil")
+                if let query = connection.query {
+                    let expectedQuery = "DROP TABLE \"Users\""
+                    let resultQuery = connection.descriptionOf(query: query)
+                    XCTAssertEqual(resultQuery, expectedQuery, "Table Drop Failed: Invalid query")
                 }
                 expectation.fulfill()
             }


### PR DESCRIPTION
This PR updates the ORM to pass a provided `Database` through functions that accept it to the underlying task execution.

Resolves #100 