### PR TITLE
Add property to set encoding format for `Date` properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ By default any property on your Model that is declared as a `Date` will be encod
 
 You can change this behaviour by overriding the default value of the property `dateEncodingStrategy`. The dateEncodingStrategy will apply to all Date properties on your Model.
 
-The example below declares a model which will have its Date properties endowed and decoded as a timestamp”
+The example below defines a model which will have its Date properties encoded and decoded as a timestamp”
 
 ```swift
 

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ By default any property on your Model that is declared as a `Date` will be encod
 
 You can change this behaviour by overriding the default value of the property `dateEncodingStrategy`. The dateEncodingStrategy will apply to all Date properties on your Model.
 
-The example below defines a model which will have its Date properties encoded and decoded as a timestamp”
+The example below defines a model which will have its Date properties encoded and decoded as a timestamp:
 
 ```swift
 

--- a/README.md
+++ b/README.md
@@ -394,6 +394,27 @@ specificPerson.save() { (savedPerson, error) in
 
 **NOTE** - When using manual or optional ID properties, you should be prepared to handle violation of unique identifier constraints. These can occur if you attempt to save a model with an ID that already exists, or in the case of Postgres, if the auto-incremented value collides with an ID that was previously inserted explicitly.
 
+## Alternative encoding for `Date` properties
+
+By default any property on your Model that is declared as a `Date` will be encoded and decoded as a `Double`.
+
+You can change this behaviour by overriding the default value of the property `dateEncodingStrategy`. The dateEncodingStrategy will apply to all Date properties on your Model.
+
+The example below declares a model which will have its Date properties endowed and decoded as a timestamp”
+
+```swift
+
+struct Person: Model {
+
+    static var dateEncodingStrategy: DateEncodingFormat = .timestamp
+
+    var firstname: String
+    var surname: String
+    var age: Int
+    var dob: Date
+}
+```
+
 ## List of plugins
 
 * [PostgreSQL](https://github.com/IBM-Swift/Swift-Kuery-PostgreSQL)

--- a/Sources/SwiftKueryORM/DatabaseDecoder.swift
+++ b/Sources/SwiftKueryORM/DatabaseDecoder.swift
@@ -200,7 +200,7 @@ open class DatabaseDecoder {
                     let castValue = try castedValue(value, Double.self, key)
                     let date = Date(timeIntervalSinceReferenceDate: castValue)
                     return try castedValue(date, type, key)
-                case .datetime, .timestamp:
+                case .timestamp:
                     if let dateValue = value as? Date {
                         return try castedValue(dateValue, type.self, key)
                     } else {

--- a/Sources/SwiftKueryORM/DatabaseDecoder.swift
+++ b/Sources/SwiftKueryORM/DatabaseDecoder.swift
@@ -201,23 +201,35 @@ open class DatabaseDecoder {
                     let date = Date(timeIntervalSinceReferenceDate: castValue)
                     return try castedValue(date, type, key)
                 case .datetime, .timestamp:
-                    let dateFormatter = DateFormatter()
-                    dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-                    let castValue = try castedValue(value, String.self, key)
-                    let date = dateFormatter.date(from: castValue)
-                    return try castedValue(date, type, key)
+                    if let dateValue = value as? Date {
+                        return try castedValue(dateValue, type.self, key)
+                    } else {
+                        let castValue = try castedValue(value, String.self, key)
+                        let dateFormatter = DateFormatter()
+                        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+                        let date = dateFormatter.date(from: castValue)
+                        return try castedValue(date, type.self, key)
+                    }
                 case .date:
-                    let dateFormatter = DateFormatter()
-                    dateFormatter.dateFormat = "yyyy-MM-dd"
-                    let castValue = try castedValue(value, String.self, key)
-                    let date = dateFormatter.date(from: castValue)
-                    return try castedValue(date, type, key)
+                    if let dateValue = value as? Date {
+                        return try castedValue(dateValue, type.self, key)
+                    } else {
+                        let castValue = try castedValue(value, String.self, key)
+                        let dateFormatter = DateFormatter()
+                        dateFormatter.dateFormat = "yyyy-MM-dd"
+                        let date = dateFormatter.date(from: castValue)
+                        return try castedValue(date, type.self, key)
+                    }
                 case .time:
-                    let dateFormatter = DateFormatter()
-                    dateFormatter.dateFormat = "HH:mm:ss"
-                    let castValue = try castedValue(value, String.self, key)
-                    let date = dateFormatter.date(from: castValue)
-                    return try castedValue(date, type, key)
+                    if let dateValue = value as? Date {
+                        return try castedValue(dateValue, type.self, key)
+                    } else {
+                        let castValue = try castedValue(value, String.self, key)
+                        let dateFormatter = DateFormatter()
+                        dateFormatter.dateFormat = "HH:mm:ss"
+                        let date = dateFormatter.date(from: castValue)
+                        return try castedValue(date, type.self, key)
+                    }
                 }
             } else {
                 throw RequestError(.ormDatabaseDecodingError, reason: "Unsupported type: \(String(describing: type)) for value: \(String(describing: value))")

--- a/Sources/SwiftKueryORM/DatabaseEncoder.swift
+++ b/Sources/SwiftKueryORM/DatabaseEncoder.swift
@@ -71,7 +71,7 @@ fileprivate struct _DatabaseKeyedEncodingContainer<K: CodingKey> : KeyedEncoding
             switch encoder.dateEncodingStrategy {
             case .double:
                 encoder.values[key.stringValue] = dateValue.timeIntervalSinceReferenceDate
-            case .datetime, .timestamp:
+            case .timestamp:
                 let dateFormatter = DateFormatter()
                 dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
                 encoder.values[key.stringValue] = dateFormatter.string(from: dateValue)

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -42,7 +42,7 @@ public protocol Model: Codable {
     static var idKeypath: IDKeyPath {get}
 
     /// Defines the date encoding strategy for the Model. Defaults to .double
-    static var dateEncodingStrategy: DateEncodingFormat { get }
+    static var dateEncodingFormat: DateEncodingFormat { get }
 
     /// Call to create the table in the database synchronously
     static func createTableSync(using db: Database?) throws -> Bool
@@ -130,7 +130,7 @@ public extension Model {
 
     static var idKeypath: IDKeyPath { return nil }
 
-    static var dateEncodingStrategy: DateEncodingFormat { return .double }
+    static var dateEncodingFormat: DateEncodingFormat { return .double }
 
     private static func executeTask(using db: Database? = nil, task: @escaping ((Connection?, QueryError?) -> ())) {
         guard let database = db ?? Database.default else {
@@ -245,7 +245,7 @@ public extension Model {
         var values: [String : Any]
         do {
             table = try Self.getTable()
-            values = try DatabaseEncoder().encode(self, dateEncodingStrategy: Self.dateEncodingStrategy)
+            values = try DatabaseEncoder().encode(self, dateEncodingStrategy: Self.dateEncodingFormat)
         } catch let error {
             onCompletion(nil, Self.convertError(error))
             return
@@ -264,7 +264,7 @@ public extension Model {
         var values: [String : Any]
         do {
             table = try Self.getTable()
-            values = try DatabaseEncoder().encode(self, dateEncodingStrategy: Self.dateEncodingStrategy)
+            values = try DatabaseEncoder().encode(self, dateEncodingStrategy: Self.dateEncodingFormat)
         } catch let error {
             onCompletion(nil, nil, Self.convertError(error))
             return
@@ -282,7 +282,7 @@ public extension Model {
         var values: [String: Any]
         do {
             table = try Self.getTable()
-            values = try DatabaseEncoder().encode(self, dateEncodingStrategy: Self.dateEncodingStrategy)
+            values = try DatabaseEncoder().encode(self, dateEncodingStrategy: Self.dateEncodingFormat)
         } catch let error {
             onCompletion(nil, Self.convertError(error))
             return
@@ -512,7 +512,7 @@ public extension Model {
 
                     var decodedModel: Self
                     do {
-                        decodedModel = try DatabaseDecoder().decode(Self.self, dictionaryTitleToValue, dateEncodingStrategy: Self.dateEncodingStrategy)
+                        decodedModel = try DatabaseDecoder().decode(Self.self, dictionaryTitleToValue, dateEncodingStrategy: Self.dateEncodingFormat)
                     } catch {
                         onCompletion(nil, Self.convertError(error))
                         return
@@ -575,7 +575,7 @@ public extension Model {
 
                     var decodedModel: Self
                     do {
-                        decodedModel = try DatabaseDecoder().decode(Self.self, dictionaryTitleToValue, dateEncodingStrategy: Self.dateEncodingStrategy)
+                        decodedModel = try DatabaseDecoder().decode(Self.self, dictionaryTitleToValue, dateEncodingStrategy: Self.dateEncodingFormat)
                     } catch {
                         onCompletion(nil, nil, Self.convertError(error))
                         return
@@ -631,7 +631,7 @@ public extension Model {
                     for dictionary in dictionariesTitleToValue {
                         var decodedModel: Self
                         do {
-                            decodedModel = try DatabaseDecoder().decode(Self.self, dictionary, dateEncodingStrategy: Self.dateEncodingStrategy)
+                            decodedModel = try DatabaseDecoder().decode(Self.self, dictionary, dateEncodingStrategy: Self.dateEncodingFormat)
                         } catch {
                             onCompletion(nil, Self.convertError(error))
                             return
@@ -696,7 +696,7 @@ public extension Model {
                     for dictionary in dictionariesTitleToValue {
                         var decodedModel: Self
                         do {
-                            decodedModel = try DatabaseDecoder().decode(Self.self, dictionary, dateEncodingStrategy: Self.dateEncodingStrategy)
+                            decodedModel = try DatabaseDecoder().decode(Self.self, dictionary, dateEncodingStrategy: Self.dateEncodingFormat)
                         } catch let error {
                             onCompletion(nil, Self.convertError(error))
                             return
@@ -766,7 +766,7 @@ public extension Model {
 
     static func getTable() throws -> Table {
         let idKeyPathSet: Bool = Self.idKeypath != nil
-        return try Database.tableInfo.getTable((Self.idColumnName, Self.idColumnType, idKeyPathSet), Self.tableName, for: Self.self, with: Self.dateEncodingStrategy)
+        return try Database.tableInfo.getTable((Self.idColumnName, Self.idColumnType, idKeyPathSet), Self.tableName, for: Self.self, with: Self.dateEncodingFormat)
     }
 
     /**

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -19,6 +19,13 @@ import KituraContracts
 import Foundation
 import Dispatch
 
+public enum DateEncodingFormat {
+    case time
+    case date
+    case timestamp, datetime
+    case double
+}
+
 /// Protocol Model conforming to Codable defining the available operations
 public protocol Model: Codable {
     /// Defines the tableName in the Database
@@ -33,6 +40,9 @@ public protocol Model: Codable {
 
     /// Defines the keypath to the Models id field
     static var idKeypath: IDKeyPath {get}
+
+    /// Defines the date encoding strategy for the Model. Defaults to .double
+    static var dateEncodingStrategy: DateEncodingFormat { get }
 
     /// Call to create the table in the database synchronously
     static func createTableSync(using db: Database?) throws -> Bool
@@ -119,6 +129,8 @@ public extension Model {
     static var idColumnType: SQLDataType.Type { return Int64.self }
 
     static var idKeypath: IDKeyPath { return nil }
+
+    static var dateEncodingStrategy: DateEncodingFormat { return .double }
 
     private static func executeTask(using db: Database? = nil, task: @escaping ((Connection?, QueryError?) -> ())) {
         guard let database = db ?? Database.default else {
@@ -233,7 +245,7 @@ public extension Model {
         var values: [String : Any]
         do {
             table = try Self.getTable()
-            values = try DatabaseEncoder().encode(self)
+            values = try DatabaseEncoder().encode(self, dateEncodingStrategy: Self.dateEncodingStrategy)
         } catch let error {
             onCompletion(nil, Self.convertError(error))
             return
@@ -252,7 +264,7 @@ public extension Model {
         var values: [String : Any]
         do {
             table = try Self.getTable()
-            values = try DatabaseEncoder().encode(self)
+            values = try DatabaseEncoder().encode(self, dateEncodingStrategy: Self.dateEncodingStrategy)
         } catch let error {
             onCompletion(nil, nil, Self.convertError(error))
             return
@@ -270,7 +282,7 @@ public extension Model {
         var values: [String: Any]
         do {
             table = try Self.getTable()
-            values = try DatabaseEncoder().encode(self)
+            values = try DatabaseEncoder().encode(self, dateEncodingStrategy: Self.dateEncodingStrategy)
         } catch let error {
             onCompletion(nil, Self.convertError(error))
             return
@@ -500,7 +512,7 @@ public extension Model {
 
                     var decodedModel: Self
                     do {
-                        decodedModel = try DatabaseDecoder().decode(Self.self, dictionaryTitleToValue)
+                        decodedModel = try DatabaseDecoder().decode(Self.self, dictionaryTitleToValue, dateEncodingStrategy: Self.dateEncodingStrategy)
                     } catch {
                         onCompletion(nil, Self.convertError(error))
                         return
@@ -563,7 +575,7 @@ public extension Model {
 
                     var decodedModel: Self
                     do {
-                        decodedModel = try DatabaseDecoder().decode(Self.self, dictionaryTitleToValue)
+                        decodedModel = try DatabaseDecoder().decode(Self.self, dictionaryTitleToValue, dateEncodingStrategy: Self.dateEncodingStrategy)
                     } catch {
                         onCompletion(nil, nil, Self.convertError(error))
                         return
@@ -619,7 +631,7 @@ public extension Model {
                     for dictionary in dictionariesTitleToValue {
                         var decodedModel: Self
                         do {
-                            decodedModel = try DatabaseDecoder().decode(Self.self, dictionary)
+                            decodedModel = try DatabaseDecoder().decode(Self.self, dictionary, dateEncodingStrategy: Self.dateEncodingStrategy)
                         } catch {
                             onCompletion(nil, Self.convertError(error))
                             return
@@ -684,7 +696,7 @@ public extension Model {
                     for dictionary in dictionariesTitleToValue {
                         var decodedModel: Self
                         do {
-                            decodedModel = try DatabaseDecoder().decode(Self.self, dictionary)
+                            decodedModel = try DatabaseDecoder().decode(Self.self, dictionary, dateEncodingStrategy: Self.dateEncodingStrategy)
                         } catch let error {
                             onCompletion(nil, Self.convertError(error))
                             return

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -21,9 +21,13 @@ import Dispatch
 
 /// Defines the supported formats for persisiting properties of type `Date`.
 public enum DateEncodingFormat {
+    // time - Corresponds to the `time` column type
     case time
+    // date - Corresponds to the `date` column type
     case date
+    // timestamp - Corresponds to the `timestamp` column type.
     case timestamp
+    // double - This is the default encoding type and corresponds to Swifts encoding of `Date`.
     case double
 }
 

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -22,7 +22,7 @@ import Dispatch
 public enum DateEncodingFormat {
     case time
     case date
-    case timestamp, datetime
+    case timestamp
     case double
 }
 
@@ -766,7 +766,7 @@ public extension Model {
 
     static func getTable() throws -> Table {
         let idKeyPathSet: Bool = Self.idKeypath != nil
-        return try Database.tableInfo.getTable((Self.idColumnName, Self.idColumnType, idKeyPathSet), Self.tableName, for: Self.self)
+        return try Database.tableInfo.getTable((Self.idColumnName, Self.idColumnType, idKeyPathSet), Self.tableName, for: Self.self, with: Self.dateEncodingStrategy)
     }
 
     /**

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -19,15 +19,15 @@ import KituraContracts
 import Foundation
 import Dispatch
 
-/// Defines the supported formats for persisiting properties of type `Date`.
+/// The DateEncodingFormat enumeration defines the supported formats for persisiting properties of type `Date`.
 public enum DateEncodingFormat {
-    // time - Corresponds to the `time` column type
+    /// time - Corresponds to the `time` column type
     case time
-    // date - Corresponds to the `date` column type
+    /// date - Corresponds to the `date` column type
     case date
-    // timestamp - Corresponds to the `timestamp` column type.
+    /// timestamp - Corresponds to the `timestamp` column type.
     case timestamp
-    // double - This is the default encoding type and corresponds to Swifts encoding of `Date`.
+    /// double - This is the default encoding type and corresponds to Swifts encoding of `Date`.
     case double
 }
 

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -19,6 +19,7 @@ import KituraContracts
 import Foundation
 import Dispatch
 
+/// Defines the supported formats for persisiting properties of type `Date`.
 public enum DateEncodingFormat {
     case time
     case date
@@ -41,7 +42,7 @@ public protocol Model: Codable {
     /// Defines the keypath to the Models id field
     static var idKeypath: IDKeyPath {get}
 
-    /// Defines the date encoding strategy for the Model. Defaults to .double
+    /// Defines the format in which `Date` properties of the `Model` will be written to the Database. Defaults to .double
     static var dateEncodingFormat: DateEncodingFormat { get }
 
     /// Call to create the table in the database synchronously


### PR DESCRIPTION
This PR add a property to `Model` which allows the user to specify a chosen format for encoding any properties which are of type `Date` to their database.

The PR also updates the ORM to respect the value of the property when creating a table from a Model.