### PR TITLE
Correct number of clauses when filtering with an array

### DIFF
--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -901,10 +901,12 @@ public extension Model {
             }
         case .or:
             let array = value.split(separator: ",")
-            if array.count > 1 {
+            var requiredFilters = array.count
+            if requiredFilters > 1 {
                 var newFilter: Filter = (column == Parameter())
-                for _ in array {
+                while (requiredFilters - 1) > 0 {
                     newFilter = newFilter || (column == Parameter())
+                    requiredFilters -= 1
                 }
                 filter = newFilter
                 parameters = array.map { String($0) }

--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -901,20 +901,15 @@ public extension Model {
             }
         case .or:
             let array = value.split(separator: ",")
-            var requiredFilters = array.count
-            if requiredFilters > 1 {
-                var newFilter: Filter = (column == Parameter())
-                while (requiredFilters - 1) > 0 {
-                    newFilter = newFilter || (column == Parameter())
-                    requiredFilters -= 1
-                }
-                filter = newFilter
-                parameters = array.map { String($0) }
-            } else {
-                filter = (column == Parameter())
-            }
-        }
 
+            var newFilter: Filter = (column == Parameter())
+            // For every additional element we need to add an OR clause for the next parameter.
+            for _ in 1 ..< array.count {
+                newFilter = newFilter || (column == Parameter())
+            }
+            filter = newFilter
+            parameters = array.map { String($0) }
+        }
         return (filter, parameters)
     }
 

--- a/Tests/SwiftKueryORMTests/TestFind.swift
+++ b/Tests/SwiftKueryORMTests/TestFind.swift
@@ -10,6 +10,7 @@ class TestFind: XCTestCase {
             ("testFind", testFind),
             ("testFindAll", testFindAll),
             ("testFindAllMatching", testFindAllMatching),
+            ("testFindAllMatchingArrayFilter", testFindAllMatchingArrayFilter),
         ]
     }
 
@@ -134,6 +135,51 @@ class TestFind: XCTestCase {
                   let user = array[0]
                   XCTAssertEqual(user.name, "Joe")
                   XCTAssertEqual(user.age, 38)
+                }
+                expectation.fulfill()
+            }
+        })
+    }
+
+    struct AgeFilter: QueryParams {
+        let age: [Int]
+    }
+
+    /**
+     Testing that the correct SQL Query is created to retrieve all the models.
+     Testing that correct amount of models are retrieved
+     */
+    func testFindAllMatchingArrayFilter() {
+        let connection: TestConnection = createConnection(.returnThreeRows)
+        Database.default = Database(single: connection)
+        let filterArray = [38,28,36]
+        let filter = AgeFilter(age: filterArray)
+        let numberOfFilters = filterArray.count
+        performTest(asyncTasks: { expectation in
+            Person.findAll(matching: filter) { array, error in
+                XCTAssertNil(error, "Find Failed: \(String(describing: error))")
+                XCTAssertNotNil(connection.query, "Find Failed: Query is nil")
+                if let query = connection.query {
+                    let expectedPrefix = "SELECT * FROM \"People\" WHERE"
+                    let expectedClauses = [["\"People\".\"age\" = ?1", "\"People\".\"age\" = ?2", "\"People\".\"age\" = ?3"]]
+                    let expectedOperator = "OR"
+                    let resultQuery = connection.descriptionOf(query: query)
+                    XCTAssertTrue(resultQuery.hasPrefix(expectedPrefix))
+                    var numberOfClauses = 0
+                    for whereClauses in expectedClauses {
+                        var success = false
+                        for whereClause in whereClauses where resultQuery.contains(whereClause) {
+                            success = true
+                        }
+                        XCTAssertTrue(success)
+                        numberOfClauses += 1
+                    }
+                    XCTAssertTrue(resultQuery.contains(expectedOperator))
+                    XCTAssertEqual(numberOfFilters, numberOfClauses, "Incorrect number of where clauses in query")
+                }
+                XCTAssertNotNil(array, "Find Failed: No array of models returned")
+                if let array = array {
+                    XCTAssertEqual(array.count, 3, "Find Failed: \(String(describing: array.count)) is not equal to 1")
                 }
                 expectation.fulfill()
             }

--- a/Tests/SwiftKueryORMTests/TestFind.swift
+++ b/Tests/SwiftKueryORMTests/TestFind.swift
@@ -170,9 +170,9 @@ class TestFind: XCTestCase {
                         var success = false
                         for whereClause in whereClauses where resultQuery.contains(whereClause) {
                             success = true
+                            numberOfClauses += 1
                         }
                         XCTAssertTrue(success)
-                        numberOfClauses += 1
                     }
                     XCTAssertTrue(resultQuery.contains(expectedOperator))
                     XCTAssertEqual(numberOfFilters, numberOfClauses, "Incorrect number of where clauses in query")


### PR DESCRIPTION
When using QueryParams to filter using an array the ORM generates an incorrect number of clauses to append to the `WHERE` within the resulting `FIND` query.

This PR adds a test which catches the error condition along with a fix for the problem.