### PR TITLE
Prevent handling of empty array in QueryParams

### DIFF
--- a/Sources/SwiftKueryORM/Model.swift
+++ b/Sources/SwiftKueryORM/Model.swift
@@ -837,6 +837,9 @@ public extension Model {
                     opr = operation.getOperator()
                     stringValue = operation.getStringValue()
                 } else if var array = value as? Array<Any> {
+                    if array.count < 1 {
+                        throw RequestError(.ormQueryError, reason: "Empty array cannot be used in QueryParams")
+                    }
                     opr = .or
                     stringValue = String(describing: array.removeFirst())
                     for val in array {


### PR DESCRIPTION
This PR updates the ORM to throw an error when an empty array is passed through a `QueryParams` object.